### PR TITLE
Fix: do not attempt to parse assets manifest as content (fixes #44)

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -319,7 +319,7 @@ class AdaptFrameworkImport {
       this.usedContentPlugins[pluginName] = { name, path: p, version, targetAttribute }
     }))
 
-    const files = await glob(`${this.coursePath}/**/*.json`, { absolute: true })
+    const files = await glob(`${this.coursePath}/**/*.json`, { absolute: true, ignore: ['**/assets.json'] })
     return Promise.all(files.map(f => this.loadContentFile(f)))
   }
 


### PR DESCRIPTION
#44 

[//]: # (Delete as appropriate)
### Fix
* do not attempt to parse assets manifest as content

Ref https://github.com/cgkineo/adapt-authoring/issues/22

