### PR TITLE
Fix: run update on course data with original data to load course.json extension settings (fixes #53)

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -508,9 +508,8 @@ class AdaptFrameworkImport {
     const course = await this.importContentObject({ ...this.contentJson.course, tags: this.tags })
     const config = await this.importContentObject(this.contentJson.config)
     // we need to run an update with the same data to make sure all extension schema settings are applied
-    await Promise.all([course, config].map(({ _id, _type, _courseId }) => {
-      return this.importContentObject({ _id, _courseId }, { isUpdate: true })
-    }))
+    await this.importContentObject({ ...this.contentJson.course, _id: course._id }, { isUpdate: true })
+
     const { sorted, hierarchy } = await this.getSortedData()
     const errors = []
     for (const ids of sorted) {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

info: replaced promise all with simple await function for course data only, I don't think there's a need to run update on config from testing as all data is already present. 

[//]: # (Add a link to the original issue)
#53 

[//]: # (Delete as appropriate)
### Fix
* run update on course data with original data to load course.json extension settings (fixes #53)


