### PR TITLE
Fix: change migrations to not run npm install on unzipPath (fixes #67)

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -6,7 +6,7 @@ import path from 'upath'
 import semver from 'semver'
 import { exec } from 'child_process'
 
-import AdaptFrameworkUtils from './AdaptFrameworkUtils.js' 
+import AdaptFrameworkUtils from './AdaptFrameworkUtils.js'
 
 import ComponentTransform from './migrations/component.js'
 import ConfigTransform from './migrations/config.js'
@@ -279,7 +279,7 @@ class AdaptFrameworkImport {
     try {
       await fs.rm(`${this.unzipPath}/package-lock.json`)
     } catch (e) {}
-    
+
     await this.patchCustomStyle()
 
     if (!semver.satisfies(this.pkg.version, semver.major(this.framework.version).toString())) {
@@ -413,11 +413,11 @@ class AdaptFrameworkImport {
   runGruntTask (task) {
     return this.execPromise(`npx grunt ${task}`)
   }
-  
+
   async execPromise (task) {
     this.framework.log('debug', 'EXEC', task)
     return new Promise((resolve, reject) => {
-      exec(task, { cwd: this.unzipPath }, (error, stdout, stderr) => {
+      exec(task, { cwd: this.framework.path }, (error, stdout, stderr) => {
         if (stdout) this.framework.log('debug', 'EXEC_STDOUT', task, stdout)
         if (stderr) this.framework.log('debug', 'EXEC_STDERR', task, stderr)
         error ? reject(error) : resolve(stdout)
@@ -425,39 +425,23 @@ class AdaptFrameworkImport {
     })
   }
 
-    /**
-   * Copies migration scripts from every local plugin being migrated to unzipped course
-   */
-  async addMigrationScripts () {
-    if (this.pluginsToMigrate.length) {
-      this.pluginsToMigrate.forEach(async p => {
-        this.framework.log('debug', `Adding migration scripts for ${p}`)
-        const [pluginMigrationPaths] = await glob(`${this.framework.path}/**/**/${p}/migrations`)
-        if (!pluginMigrationPaths) return
-        try {
-          let [destinationPath] = await glob(`${this.unzipPath}/**/**/${p}/migrations`)
-          if (!destinationPath) {
-            const [pluginPath] = await glob(`${this.unzipPath}/**/**/${p}`)
-            destinationPath = await fs.ensureDir(path.join(pluginPath, 'migrations'))
-          }
-          await fs.copy(pluginMigrationPaths, destinationPath)
-        } catch (error) {
-          throw new Error(`Error copying migration scripts for ${p}: ${error.message}`)
-        }
-      })
-    }
-  }
-
   /**
    * Handle migrate course data, installs adapt-migrations/capture data/adds updated scripts/migrates data
    */
   async migrateCourseData () {
     try {
-      await this.execPromise('npm install adaptlearning/adapt-migrations')
-      await fs.copy(path.join(this.framework.path, 'grunt'), path.join(this.unzipPath, 'grunt'), { recursive: true })
-      await this.addMigrationScripts()
-      await this.runGruntTask('migration:capture')
-      await this.runGruntTask('migration:migrate')
+      const folderName = `${this.userId}-migrations`
+      const relativePath = path.relative(this.framework.path, this.unzipPath)
+      const outputDir = fs.existsSync(path.join(this.unzipPath, 'build'))
+        ? path.join(relativePath, 'build')
+        : path.join(relativePath, 'src');
+      const captureDir = path.join('./', folderName)
+
+      await this.runGruntTask(`migration:capture --outputdir=${outputDir} --capturedir=${captureDir}`)
+      await this.runGruntTask(`migration:migrate --outputdir=${outputDir} --capturedir=${captureDir}`)
+
+      const captureFolder = path.join(this.framework.path, captureDir)
+      await fs.remove(captureFolder)
     } catch (error) {
       this.framework.log('error', 'Migration process failed', error)
       throw error

--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -434,7 +434,7 @@ class AdaptFrameworkImport {
       const relativePath = path.relative(this.framework.path, this.unzipPath)
       const outputDir = fs.existsSync(path.join(this.unzipPath, 'build'))
         ? path.join(relativePath, 'build')
-        : path.join(relativePath, 'src');
+        : path.join(relativePath, 'src')
       const captureDir = path.join('./', folderName)
 
       await this.runGruntTask(`migration:capture --outputdir=${outputDir} --capturedir=${captureDir}`)
@@ -444,7 +444,7 @@ class AdaptFrameworkImport {
       await fs.remove(captureFolder)
     } catch (error) {
       this.framework.log('error', 'Migration process failed', error)
-      throw error
+      throw new Error(`Migration process failed: ${error.message}`)
     }
   }
 

--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -27,13 +27,11 @@ class AdaptFrameworkModule extends AbstractModule {
      * @type {Hook}
      */
     this.postInstallHook = new Hook()
-    this.postInstallHook.tap(this.installFrameworkModules())
     /**
      * Invoked after a framework update
      * @type {Hook}
      */
     this.postUpdateHook = new Hook()
-    this.postUpdateHook.tap(this.installFrameworkModules())
 
     /**
      * Invoked prior to a course being built. The AdaptFrameworkBuild instance is passed to any observers.
@@ -51,15 +49,18 @@ class AdaptFrameworkModule extends AbstractModule {
      */
     this.contentMigrations = []
 
+    const content = await this.app.waitForModule('content')
+    content.accessCheckHook.tap(this.checkContentAccess.bind(this))
+
+    this.postInstallHook.tap(this.installFrameworkModules.bind(this))
+    this.postUpdateHook.tap(this.installFrameworkModules.bind(this))
+
     await this.installFramework()
 
     if (this.app.args['update-framework'] === true) {
       await this.updateFramework()
     }
     await Promise.all([this.loadSchemas(), this.initRoutes()])
-
-    const content = await this.app.waitForModule('content')
-    content.accessCheckHook.tap(this.checkContentAccess.bind(this))
 
     this.logStatus()
   }
@@ -78,7 +79,7 @@ class AdaptFrameworkModule extends AbstractModule {
    */
   async installFrameworkModules () {
     try {
-      exec('npx install', { cwd: this.path }, (error, stdout, stderr) => {
+      exec('npm install', { cwd: this.path }, (error, stdout, stderr) => {
         if (stdout) this.log('debug', stdout)
         if (stderr) this.log('debug', stderr)
       })
@@ -120,7 +121,7 @@ class AdaptFrameworkModule extends AbstractModule {
       this.log('error', `failed to install framework, ${e.message}`)
       throw this.app.errors.FW_INSTALL_FAILED
     }
-    this.postInstallHook.invoke()
+    await this.postInstallHook.invoke()
   }
 
   /**

--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -79,7 +79,7 @@ class AdaptFrameworkModule extends AbstractModule {
    */
   async installFrameworkModules () {
     try {
-      exec('npm install', { cwd: this.path }, (error, stdout, stderr) => {
+      exec('npm install', { cwd: this.path }, (stdout, stderr) => {
         if (stdout) this.log('debug', stdout)
         if (stderr) this.log('debug', stderr)
       })

--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -8,6 +8,7 @@ import FWUtils from './AdaptFrameworkUtils.js'
 import path from 'path'
 import semver from 'semver'
 import { unzip } from 'zipper'
+import { exec } from 'child_process'
 /**
  * Module to handle the interface with the Adapt framework
  * @memberof adaptframework
@@ -26,11 +27,13 @@ class AdaptFrameworkModule extends AbstractModule {
      * @type {Hook}
      */
     this.postInstallHook = new Hook()
+    this.postInstallHook.tap(this.installFrameworkModules())
     /**
      * Invoked after a framework update
      * @type {Hook}
      */
     this.postUpdateHook = new Hook()
+    this.postUpdateHook.tap(this.installFrameworkModules())
 
     /**
      * Invoked prior to a course being built. The AdaptFrameworkBuild instance is passed to any observers.
@@ -67,6 +70,22 @@ class AdaptFrameworkModule extends AbstractModule {
    */
   get version () {
     return AdaptCli.getCurrentFrameworkVersion({ cwd: this.path })
+  }
+
+  /**
+   * Run npm install on framework directory to install/update any dependencies
+   * @type {Promise}
+   */
+  async installFrameworkModules () {
+    try {
+      exec('npx install', { cwd: this.path }, (error, stdout, stderr) => {
+        if (stdout) this.log('debug', stdout)
+        if (stderr) this.log('debug', stderr)
+      })
+    } catch (e) {
+      this.log('error', `failed to run npm install, ${e.message}`)
+      throw this.app.errors.FW_INSTALL_FAILED
+    }
   }
 
   /**


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
Utilises new FW migrations, requires new temp/adapt_framework (https://github.com/adaptlearning/adapt_framework/pull/3668) 
#67 

[//]: # (Delete as appropriate)
### Fix
* change migrations to not run npm install on unzipPath (fixes #67)


