### PR TITLE
Fix: Prevent build directory conflicts with random suffix (fixes #76)

### DIFF
--- a/lib/AdaptFrameworkBuild.js
+++ b/lib/AdaptFrameworkBuild.js
@@ -175,7 +175,9 @@ class AdaptFrameworkBuild {
     if (!this.expiresAt) {
       this.expiresAt = await AdaptFrameworkBuild.getBuildExpiry()
     }
-    this.dir = path.resolve(framework.getConfig('buildDir'), new Date().getTime().toString())
+    // random suffix to account for parallel builds executed at exactly the same millisecond
+    const randomSuffix = `_${Math.floor(Math.random() * 1000).toString().padStart(4, '0')}`
+    this.dir = path.resolve(framework.getConfig('buildDir'), Date.now() + randomSuffix)
     this.buildDir = path.join(this.dir, 'build')
     this.courseDir = path.join(this.buildDir, 'course')
 


### PR DESCRIPTION
Added a random suffix to the build directory path to prevent conflicts during parallel builds.

[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#76

[//]: # (Delete as appropriate)
### Fix
* Builds can fail when running in parallel

