### PR TITLE
Fix: Retain original value when trying to map an undefined asset `_id` (fixes #88)

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -459,10 +459,10 @@ class AdaptFrameworkImport {
       await this.patchThemeName()
       await this.patchCustomStyle()
 
-      const opts = { 
+      const opts = {
         outputDir: path.relative(this.framework.path, path.resolve(this.coursePath, '..')),
         captureDir: path.join(`./${this.userId}-migrations`),
-        outputFilePath: path.join(this.framework.path, 'migrations', `${this.userId}.txt`) 
+        outputFilePath: path.join(this.framework.path, 'migrations', `${this.userId}.txt`)
       }
       FWUtils.logDir('captureDir', opts.captureDir)
       FWUtils.logDir('outputDir', opts.outputDir)


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#88

[//]: # (Delete as appropriate)
### Fix
* Retain original value when trying to map an undefined asset `_id`