### PR TITLE
Fix: Make sure language is set before preImportHook is invoked (fixes #100)

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -307,7 +307,8 @@ class AdaptFrameworkImport {
     this.coursePath = courseDirs[0]
     try {
       await this.loadContentFile(`${this.coursePath}/config.json`)
-      this.langPath = `${this.coursePath}/${this.language ?? this.contentJson.config._defaultLanguage}`
+      this.language = this.language ?? this.contentJson.config._defaultLanguage
+      this.langPath = `${this.coursePath}/${this.language}`
       await fs.readdir(this.langPath)
     } catch (e) {
       this.framework.log('error', e)


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#100 

[//]: # (Delete as appropriate)
### Fix
* Make sure import language can be undefined when preImportHook is invoked


