### PR TITLE
Fix: Remove direct use of npm after install (fixes #107)

### DIFF
--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -96,10 +96,11 @@ class AdaptFrameworkModule extends AbstractModule {
     try {
       try {
         await fs.readFile(path.resolve(this.path, 'package.json'))
-        force ?
-          this.log('verbose', 'INSTALL forcing new framework install') :
+        if (force) {
+          this.log('verbose', 'INSTALL forcing new framework install')
+        } else {
           return this.log('verbose', 'INSTALL no action, force !== true')
-        
+        }
         await fs.rm(this.path, { recursive: true })
       } catch (e) {
         // package is missing, an install is required


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#107 

[//]: # (Delete as appropriate)
### Fix
* Remove direct use of npm after framework install (already handled by the adapt-cli)