### PR TITLE
Fix: Add isDryRun default value and harden task runner condition (fixes #158)

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -76,7 +76,7 @@ class AdaptFrameworkImport {
    * @constructor
    * @param {AdaptFrameworkImportOptions} options
    */
-  constructor ({ importPath, userId, language, assetFolders, tags, isDryRun, importContent = true, importPlugins = true, migrateContent = true, updatePlugins = false, removeSource = true }) {
+  constructor ({ importPath, userId, language, assetFolders, tags, isDryRun = false, importContent = true, importPlugins = true, migrateContent = true, updatePlugins = false, removeSource = true }) {
     const e = App.instance.errors.INVALID_PARAMS
     if (!importPath) throw e.setData({ params: ['importPath'] })
     if (!userId) throw e.setData({ params: ['userId'] })
@@ -274,8 +274,8 @@ class AdaptFrameworkImport {
         [this.importCourseData, !isDryRun && importContent],
         [this.generateSummary]
       ]
-      for (const [func, test] of tasks) {
-        if (test === true || test === undefined) await func.call(this)
+      for (const task of tasks) {
+        if (task.length < 2 || task[1]) await task[0].call(this)
       }
       await this.postImportHook.invoke(this)
     } catch (e) {


### PR DESCRIPTION
### Fix
* Add `isDryRun = false` default to match all other boolean import settings
* Replace `test === undefined` check with length-based check that distinguishes "no condition" from "falsy condition"

### Problem
When `isDryRun` is not passed to `AdaptFrameworkImport`, it stays `undefined`. The `&&` short-circuit produces `undefined` (not `false`), which the task runner's `test === undefined` check treats as "always run" — causing both dry-run and non-dry-run branches to execute.

This results in `importCoursePlugins` and `loadCourseData` running twice per import, inflating the component count from 23 to 58 and failing integration tests.

### Testing
1. Run integration tests: `npx at-integration-test adaptframework-import`
2. Verify "should have created components" passes with expected count of 23
3. Verify import logs show `loadCourseData` and `importCoursePlugins` running once (not twice) per non-dry import

🤖 Generated with [Claude Code](https://claude.com/claude-code)