### PR TITLE
Fix: detect missing plugins early and fix failed import cleanup

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -431,6 +431,7 @@ class AdaptFrameworkImport {
         if (pluginData[type] !== undefined) return type
       }
     }
+    this.configEnabledPlugins = this.contentJson.config?._enabledPlugins ?? []
     await Promise.all(usedPluginPaths.map(async p => {
       const bowerJson = await readJson(`${p}/bower.json`)
       const { name, version, targetAttribute } = bowerJson
@@ -613,6 +614,17 @@ class AdaptFrameworkImport {
    */
   async importCoursePlugins () {
     this.installedPlugins = (await this.contentplugin.find({})).reduce((m, p) => Object.assign(m, { [p.name]: p }), {})
+    const missingFromBoth = this.configEnabledPlugins.filter(p =>
+      !this.usedContentPlugins[p] && !this.installedPlugins[p]
+    )
+    if (missingFromBoth.length) {
+      if (this.settings.isDryRun) {
+        this.statusReport.error.push({ code: 'MISSING_PLUGINS', data: missingFromBoth })
+        return
+      }
+      throw App.instance.errors.FW_IMPORT_MISSING_PLUGINS
+        .setData({ plugins: missingFromBoth.join(', ') })
+    }
     const pluginsToInstall = []
     const pluginsToUpdate = []
 
@@ -858,38 +870,67 @@ class AdaptFrameworkImport {
    * @return {Promise}
    */
   async cleanUp (error) {
-    if (!this.settings.removeSource) {
-      return
+    if (error) {
+      await this.rollback()
     }
-    try {
-      const tasks = [fs.rm(this.path, { recursive: true })]
-      if (error) {
-        // Uninstall newly installed plugins
-        tasks.push(Promise.all(Object.values(this.newContentPlugins).map(p => this.contentplugin.uninstallPlugin(p._id))))
-        // Restore updated plugins to their original versions
-        if (Object.keys(this.updatedContentPlugins).length > 0) {
-          tasks.push(this.restoreUpdatedPlugins())
-        }
-        // Delete imported assets
-        tasks.push(Promise.all(Object.values(this.assetMap).map(a => this.assets.delete({ _id: a }))))
-        // Delete newly created tags
-        if (this.newTagIds.length > 0) {
-          const tags = await App.instance.waitForModule('tags')
-          tasks.push(Promise.all(this.newTagIds.map(id => tags.delete({ _id: id }))))
-        }
-        let _courseId
-        try {
-          _courseId = parseObjectId(this.idMap[this.contentJson.course._id])
-        } catch (e) {}
-        if (_courseId) {
-          tasks.push(
-            this.content.deleteMany({ _courseId }),
-            this.courseassets.deleteMany({ courseId: _courseId })
-          )
-        }
+    if (this.settings.removeSource) {
+      try {
+        await fs.rm(this.path, { recursive: true })
+      } catch (e) {} // ignore source removal errors
+    }
+  }
+
+  /**
+   * Rolls back all changes made during a failed import
+   * @return {Promise}
+   */
+  async rollback () {
+    log('info', 'rolling back failed import')
+    const tasks = []
+    // Uninstall newly installed plugins
+    if (this.contentplugin) {
+      tasks.push(...Object.values(this.newContentPlugins).map(p =>
+        this.contentplugin.uninstallPlugin(p._id)
+          .catch(e => log('warn', `failed to uninstall plugin '${p.name}'`, e))
+      ))
+    }
+    // Restore updated plugins to their original versions
+    if (Object.keys(this.updatedContentPlugins).length) {
+      tasks.push(this.restoreUpdatedPlugins())
+    }
+    // Delete imported assets
+    if (this.assets) {
+      tasks.push(...Object.values(this.assetMap).map(id =>
+        this.assets.delete({ _id: id })
+          .catch(e => log('warn', `failed to delete asset '${id}'`, e))
+      ))
+    }
+    // Delete newly created tags
+    if (this.newTagIds.length) {
+      try {
+        const tags = await App.instance.waitForModule('tags')
+        tasks.push(...this.newTagIds.map(id =>
+          tags.delete({ _id: id })
+            .catch(e => log('warn', `failed to delete tag '${id}'`, e))
+        ))
+      } catch (e) {
+        log('warn', 'failed to load tags module for rollback', e)
       }
-      await Promise.allSettled(tasks)
-    } catch (e) {} // ignore any thrown errors
+    }
+    // Delete course content and course assets
+    if (this.content) {
+      try {
+        const _courseId = parseObjectId(this.idMap[this.contentJson.course._id])
+        tasks.push(
+          this.content.deleteMany({ _courseId })
+            .catch(e => log('warn', 'failed to delete course content', e)),
+          this.courseassets.deleteMany({ courseId: _courseId })
+            .catch(e => log('warn', 'failed to delete course assets', e))
+        )
+      } catch (e) {} // courseId not available, no content to roll back
+    }
+    await Promise.allSettled(tasks)
+    log('info', 'rollback complete')
   }
 
   /**


### PR DESCRIPTION
### Fix
* Detect plugins referenced in `_enabledPlugins` that are missing from both the import package and the server early in `importCoursePlugins`, before any content is inserted — previously this wasn't caught until deep in the content insertion loop
* Error rollback now always runs on failed import regardless of the `removeSource` setting — previously `removeSource: false` skipped all cleanup including rollback
* Individual cleanup deletions (assets, plugins, tags) no longer short-circuit on the first failure — previously `Promise.all` meant one failed deletion would abandon the rest in its group
* Guard against undefined module references during rollback and log individual failures instead of silently swallowing them

### Testing
1. Export a course, remove a plugin from the export's `src/` directory (ensure it's not installed on the server), re-import — verify the import is blocked with a clear `FW_IMPORT_MISSING_PLUGINS` error listing the missing plugins
2. Repeat with `isDryRun: true` — verify the status report contains an error entry with code `MISSING_PLUGINS` without throwing
3. Trigger a failed import (e.g. with invalid content) with `removeSource: false` — verify that imported assets, plugins, tags and content are still cleaned up
4. Trigger a failed import where one asset deletion fails — verify remaining assets, plugins and tags are still cleaned up

Fixes #161