### PR TITLE
Update: Use registerRoutes utility from server module

### DIFF
--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -3,7 +3,7 @@ import AdaptFrameworkBuild from './AdaptFrameworkBuild.js'
 import AdaptFrameworkImport from './AdaptFrameworkImport.js'
 import fs from 'node:fs/promises'
 import { getHandler, postHandler, importHandler, postUpdateHandler, getUpdateHandler } from './handlers.js'
-import { loadRouteConfig } from 'adapt-authoring-server'
+import { loadRouteConfig, registerRoutes } from 'adapt-authoring-server'
 import { runCliCommand } from './utils.js'
 import path from 'node:path'
 import semver from 'semver'
@@ -233,13 +233,7 @@ class AdaptFrameworkModule extends AbstractModule {
       handlerAliases: { getHandler, postHandler, importHandler, postUpdateHandler, getUpdateHandler }
     })
     this.apiRouter = server.api.createChildRouter(config.root)
-    for (const r of config.routes) {
-      this.apiRouter.addRoute(r)
-      if (!r.permissions) continue
-      for (const [method, perms] of Object.entries(r.permissions)) {
-        auth.secureRoute(`${this.apiRouter.path}${r.route}`, method, perms)
-      }
-    }
+    registerRoutes(this.apiRouter, config.routes, auth)
   }
 
   registerImportContentMigration (migration) {


### PR DESCRIPTION
### Update
* Replace the inline route registration loop in `initRoutes()` with the new `registerRoutes` utility from `adapt-authoring-server`, reducing duplication

### Testing
1. `npx standard` passes
2. Start the app and verify adapt framework endpoints (preview, publish, import, export, update) still respond correctly