### PR TITLE
New: Add middleware hooks for import and build lifecycle

### DIFF
--- a/lib/AdaptFrameworkBuild.js
+++ b/lib/AdaptFrameworkBuild.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { App, Hook, ensureDir, writeJson } from 'adapt-authoring-core'
+import { App, ensureDir, writeJson } from 'adapt-authoring-core'
 import { parseObjectId } from 'adapt-authoring-mongodb'
 import { createWriteStream } from 'node:fs'
 import AdaptCli from 'adapt-cli'
@@ -140,16 +140,6 @@ class AdaptFrameworkBuild {
      * @type {Array<Object>}
      */
     this.disabledPlugins = []
-    /**
-     * Invoked prior to a course being built.
-     * @type {Hook}
-     */
-    this.preBuildHook = new Hook({ mutable: true })
-    /**
-      * Invoked after a course has been built.
-      * @type {Hook}
-      */
-    this.postBuildHook = new Hook({ mutable: true })
   }
 
   /**
@@ -190,8 +180,6 @@ class AdaptFrameworkBuild {
         linkNodeModules: !this.isExport
       })
     ])
-    await this.preBuildHook.invoke(this)
-
     await this.writeContentJson()
 
     logDir('courseDir', this.courseDir)
@@ -218,8 +206,6 @@ class AdaptFrameworkBuild {
     } else {
       this.location = this.isPreview ? path.join(this.dir, 'build') : this.dir
     }
-    await this.postBuildHook.invoke(this)
-
     this.buildData = await this.recordBuildAttempt()
 
     return this

--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -1,4 +1,4 @@
-import { App, Hook, spawn, readJson, writeJson } from 'adapt-authoring-core'
+import { App, spawn, readJson, writeJson } from 'adapt-authoring-core'
 import { parseObjectId } from 'adapt-authoring-mongodb'
 import fs from 'node:fs/promises'
 import { glob } from 'glob'
@@ -195,15 +195,6 @@ class AdaptFrameworkImport {
       removeSource
     }
     /**
-     * Invoked before the import process has started
-     */
-    this.preImportHook = new Hook()
-    /**
-     * Invoked once the import process has completed
-     */
-    this.postImportHook = new Hook()
-
-    /**
      * plugins on import that are of a lower version than the installed version
      * @type {Array}
      */
@@ -264,7 +255,6 @@ class AdaptFrameworkImport {
         [this.prepare],
         [this.loadAssetData],
         [this.loadPluginData],
-        [() => this.preImportHook.invoke(this)],
         [this.importTags, importContent],
         [this.importCourseAssets, importContent],
         [this.importCoursePlugins, isDryRun && importPlugins],
@@ -278,7 +268,6 @@ class AdaptFrameworkImport {
       for (const task of tasks) {
         if (task.length < 2 || task[1]) await task[0].call(this)
       }
-      await this.postImportHook.invoke(this)
     } catch (e) {
       error = e
     }

--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -53,6 +53,18 @@ class AdaptFrameworkModule extends AbstractModule {
      */
     this.postBuildHook = new Hook({ mutable: true })
     /**
+     * Middleware hook wrapping the full import lifecycle (pre → import → post).
+     * Observers receive (next, importer) and must call next() to proceed.
+     * @type {Hook}
+     */
+    this.importHook = new Hook({ type: Hook.Types.Middleware })
+    /**
+     * Middleware hook wrapping the full build lifecycle (pre → build → post).
+     * Observers receive (next, builder) and must call next() to proceed.
+     * @type {Hook}
+     */
+    this.buildHook = new Hook({ type: Hook.Types.Middleware })
+    /**
      * Content migration functions to be run on import
      * @type {Array}
      */
@@ -250,9 +262,16 @@ class AdaptFrameworkModule extends AbstractModule {
    */
   async buildCourse (options) {
     const builder = new AdaptFrameworkBuild(options)
-    builder.preBuildHook.tap(() => this.preBuildHook.invoke(builder))
-    builder.postBuildHook.tap(() => this.postBuildHook.invoke(builder))
-    return builder.build()
+    const core = async () => {
+      await this.preBuildHook.invoke(builder)
+      await builder.build()
+      await this.postBuildHook.invoke(builder)
+      return builder
+    }
+    if (this.buildHook.hasObservers) {
+      return this.buildHook.invoke(core, builder)
+    }
+    return core()
   }
 
   /**
@@ -262,9 +281,16 @@ class AdaptFrameworkModule extends AbstractModule {
    */
   async importCourse (options) {
     const importer = new AdaptFrameworkImport(options)
-    importer.preImportHook.tap(() => this.preImportHook.invoke(importer))
-    importer.postImportHook.tap(() => this.postImportHook.invoke(importer))
-    return importer.import()
+    const core = async () => {
+      await this.preImportHook.invoke(importer)
+      await importer.import()
+      await this.postImportHook.invoke(importer)
+      return importer
+    }
+    if (this.importHook.hasObservers) {
+      return this.importHook.invoke(core, importer)
+    }
+    return core()
   }
 }
 


### PR DESCRIPTION
## Summary
* Add `importHook` and `buildHook` middleware hooks to `AdaptFrameworkModule`, following the `AbstractApiModule` pattern
* Refactor `importCourse`/`buildCourse` to invoke module-level pre/post hooks directly via a `core()` function
* Remove per-instance relay hooks from `AdaptFrameworkImport` and `AdaptFrameworkBuild`

Closes #170

### New
* Middleware hooks (`importHook`, `buildHook`) that allow observers to wrap the full import/build lifecycle with a `next()` function

### Testing
1. Verify existing `preBuildHook` consumers (`coursetheme`, `browserslist`) still work — build a course via preview/publish
2. Import a course and confirm `preImportHook`/`postImportHook` observers still fire
3. Tap the new `importHook` middleware and verify `(next, importer)` signature works