### PR TITLE
Fix: Map duplicate assets during import instead of warning

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -600,7 +600,12 @@ class AdaptFrameworkImport {
         const resolved = path.relative(`${this.coursePath}/..`, filepath)
         this.assetMap[resolved] = asset._id.toString()
       } catch (e) {
-        this.statusReport.warn.push({ code: 'ASSET_IMPORT_FAILED', data: { filepath } })
+        if (e.code === 'DUPLICATE_ASSET') {
+          const resolved = path.relative(`${this.coursePath}/..`, filepath)
+          this.assetMap[resolved] = e.data.assetId
+        } else {
+          this.statusReport.warn.push({ code: 'ASSET_IMPORT_FAILED', data: { filepath } })
+        }
       }
       imagesImported++
     }))


### PR DESCRIPTION
### Refs adapt-security/adapt-authoring-assets#61

### Fix
- When `DUPLICATE_ASSET` is thrown during course import, map the existing asset's ID into `assetMap` instead of logging a warning and losing the reference
- Prevents broken asset references in imported content when the same file already exists

### Testing
- Import a course containing an asset that already exists in the system
- Verify the imported content correctly references the existing asset rather than showing broken references