### PR TITLE
Fix: suppress stale browserslist data warning

### DIFF
--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -76,6 +76,8 @@ class AdaptFrameworkModule extends AbstractModule {
 
     await this.installFramework()
 
+    process.env.BROWSERSLIST_IGNORE_OLD_DATA = '1'
+
     if (this.app.args['update-framework'] === true) {
       await this.updateFramework()
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test": "node --test --test-force-exit --experimental-test-module-mocks 'tests/**/*.spec.js'"
   },
   "dependencies": {
-    "adapt-authoring-browserslist": "^1.3.4",
     "adapt-authoring-content": "^2.0.0",
     "adapt-authoring-contentplugin": "^1.0.3",
     "adapt-authoring-core": "^2.0.0",


### PR DESCRIPTION
### Fix

- Set `BROWSERSLIST_IGNORE_OLD_DATA=1` env var during module init to suppress false-positive "caniuse-lite data is X months old" warnings during builds
- Remove `adapt-authoring-browserslist` dependency as it is no longer needed — the upstream `caniuse-lite` package on npm already contains the latest available data, making the update module redundant

### Testing

- [ ] Verify build completes without browserslist warning
- [ ] Verify no errors from missing browserslist module