### PR TITLE
New: Support content-only builds via outputDir option

### DIFF
--- a/lib/AdaptFrameworkBuild.js
+++ b/lib/AdaptFrameworkBuild.js
@@ -40,11 +40,12 @@ class AdaptFrameworkBuild {
    * @property {String} userId The user executing the build
    * @property {String} expiresAt When the build expires
    * @property {Boolean} compress Whether output files should be compressed into an archive file
+   * @property {String} outputDir If set, uses this as the build root. If the directory already exists, only content data and assets are written (framework copy and compilation are skipped)
    *
    * @constructor
    * @param {AdaptFrameworkBuildOptions} options
    */
-  constructor ({ action, courseId, userId, expiresAt, compress }) {
+  constructor ({ action, courseId, userId, expiresAt, compress, outputDir }) {
     /**
      * The MongoDB collection name
      * @type {String}
@@ -150,6 +151,11 @@ class AdaptFrameworkBuild {
       * @type {Hook}
       */
     this.postBuildHook = new Hook({ mutable: true })
+    /**
+     * Custom output directory. If the directory already exists, only content and assets are written
+     * @type {String}
+     */
+    this.outputDir = outputDir ?? null
   }
 
   /**
@@ -164,17 +170,26 @@ class AdaptFrameworkBuild {
     if (!this.expiresAt) {
       this.expiresAt = await AdaptFrameworkBuild.getBuildExpiry()
     }
-    // random suffix to account for parallel builds executed at exactly the same millisecond
-    const randomSuffix = `_${Math.floor(Math.random() * 1000).toString().padStart(4, '0')}`
-    this.dir = path.resolve(framework.getConfig('buildDir'), Date.now() + randomSuffix)
+    if (this.outputDir) {
+      this.dir = this.outputDir
+    } else {
+      // random suffix to account for parallel builds executed at exactly the same millisecond
+      const randomSuffix = `_${Math.floor(Math.random() * 1000).toString().padStart(4, '0')}`
+      this.dir = path.resolve(framework.getConfig('buildDir'), Date.now() + randomSuffix)
+    }
     this.buildDir = path.join(this.dir, 'build')
     this.courseDir = path.join(this.buildDir, 'course')
+
+    const dirExists = await fs.access(this.dir).then(() => true, () => false)
+    const contentOnly = this.outputDir && dirExists
 
     const cacheDir = path.join(framework.getConfig('buildDir'), 'cache')
 
     await ensureDir(this.dir)
     await ensureDir(this.buildDir)
-    await ensureDir(cacheDir)
+    if (!contentOnly) {
+      await ensureDir(cacheDir)
+    }
 
     logDir('dir', this.dir)
     logDir('buildDir', this.buildDir)
@@ -182,21 +197,23 @@ class AdaptFrameworkBuild {
 
     await this.loadCourseData()
 
-    await Promise.all([
-      this.copyAssets(),
-      copyFrameworkSource({
+    const tasks = [this.copyAssets()]
+    if (!contentOnly) {
+      tasks.push(copyFrameworkSource({
         destDir: this.dir,
         enabledPlugins: this.enabledPlugins.map(p => p.name),
         linkNodeModules: !this.isExport
-      })
-    ])
+      }))
+    }
+    await Promise.all(tasks)
+
     await this.preBuildHook.invoke(this)
 
     await this.writeContentJson()
 
     logDir('courseDir', this.courseDir)
 
-    if (!this.isExport) {
+    if (!contentOnly && !this.isExport) {
       try {
         logMemory()
         await AdaptCli.buildCourse({


### PR DESCRIPTION
### Fixes #179

### New

- Added `outputDir` option to `AdaptFrameworkBuild` constructor
- When `outputDir` is set and the directory already exists, the build writes only content JSON and assets (skips framework source copy and Adapt CLI compilation)
- When `outputDir` is set but the directory does not exist, a full build is performed into the specified directory

### Testing

- Build a course with `outputDir` pointing to a new directory — verify full build runs
- Build again with `outputDir` pointing to that existing directory — verify only content JSON and assets are written
- Build without `outputDir` — verify existing behaviour is unchanged
- Verify export builds still work correctly with the new option