### PR TITLE
Update: Adapt to synchronous adapt-schemas v3 API

### DIFF
--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -289,7 +289,7 @@ class AdaptFrameworkModule extends AbstractModule {
   async loadSchemas () {
     const jsonschema = await this.app.waitForModule('jsonschema')
     const schemas = (await this.runCliCommand('getSchemaPaths')).filter(s => s.includes('/core/'))
-    await Promise.all(schemas.map(s => jsonschema.registerSchema(s)))
+    schemas.forEach(s => jsonschema.registerSchema(s))
   }
 
   /**


### PR DESCRIPTION
### Fixes #184
### Refs adapt-security/adapt-authoring-jsonschema#58

### Update

- `loadSchemas()` — replaced `await Promise.all(schemas.map(...))` with synchronous `forEach` since `registerSchema()` is now synchronous in adapt-schemas v3
- `applySchemaDefaults()` — replaced `validateWithDefaults` try/catch workaround with `schema.validate(data, { useDefaults: true, ignoreErrors: true })` now available in adapt-schemas v3

### Testing

- [ ] Verify framework schemas are still loaded correctly on startup
- [ ] Verify course builds apply schema defaults correctly (check default values appear in output JSON)