### PR TITLE
Chore: Remove adapt-octopus dependency

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -2,7 +2,6 @@ import { App, Hook, spawn, readJson, writeJson } from 'adapt-authoring-core'
 import { parseObjectId } from 'adapt-authoring-mongodb'
 import fs from 'node:fs/promises'
 import { glob } from 'glob'
-import octopus from 'adapt-octopus'
 import path from 'upath'
 import { randomBytes } from 'node:crypto'
 import semver from 'semver'
@@ -344,19 +343,7 @@ class AdaptFrameworkImport {
       }
       this.statusReport.info.push({ code: 'MIGRATE_CONTENT', data })
     }
-    await this.convertSchemas()
     log('debug', 'preparation tasks completed successfully')
-  }
-
-  /**
-   * Converts all properties.schema files to a valid JSON schema format
-   * @return {Promise}
-   */
-  async convertSchemas () {
-    return octopus.runRecursive({
-      cwd: this.path,
-      logger: { log: (...args) => log('debug', ...args) }
-    })
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "adapt-authoring-mongodb": "^3.0.0",
     "adapt-authoring-spoortracking": "^1.0.2",
     "adapt-cli": "^3.3.3",
-    "adapt-octopus": "^0.1.2",
     "bytes": "^3.1.2",
     "fs-extra": "11.3.3",
     "glob": "^13.0.0",


### PR DESCRIPTION
### Chore
- Removed `adapt-octopus` dependency and `convertSchemas()` method from `AdaptFrameworkImport`
- The `properties.schema` to JSON schema conversion is no longer needed as all courses now use standard JSON schemas