### PR TITLE
Fix: Skip de-duplicated assets in import rollback

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -170,6 +170,11 @@ class AdaptFrameworkImport {
      */
     this.newTagIds = []
     /**
+     * Array of asset IDs newly created during import for rollback. Excludes assets de-duplicated to existing records.
+     * @type {Array<String>}
+     */
+    this.newAssetIds = []
+    /**
      * Contains non-fatal infomation messages regarding import status which can be return as response data. Fatal errors are thrown in the usual way.
      * @type {Object}
      */
@@ -595,7 +600,9 @@ class AdaptFrameworkImport {
         })
         // store the asset _id so we can map it to the old path later
         const resolved = path.relative(`${this.coursePath}/..`, filepath)
-        this.assetMap[resolved] = asset._id.toString()
+        const assetId = asset._id.toString()
+        this.assetMap[resolved] = assetId
+        this.newAssetIds.push(assetId)
       } catch (e) {
         if (e.code === 'DUPLICATE_ASSET') {
           const resolved = path.relative(`${this.coursePath}/..`, filepath)
@@ -902,9 +909,9 @@ class AdaptFrameworkImport {
     if (Object.keys(this.updatedContentPlugins).length) {
       tasks.push(this.restoreUpdatedPlugins())
     }
-    // Delete imported assets
-    if (this.assets) {
-      tasks.push(...Object.values(this.assetMap).map(id =>
+    // Delete newly created assets (skip de-duplicated assets which point to pre-existing records)
+    if (this.assets && this.newAssetIds.length) {
+      tasks.push(...this.newAssetIds.map(id =>
         this.assets.delete({ _id: id })
           .catch(e => log('warn', `failed to delete asset '${id}'`, e))
       ))

--- a/tests/AdaptFrameworkImport.spec.js
+++ b/tests/AdaptFrameworkImport.spec.js
@@ -404,6 +404,7 @@ describe('AdaptFrameworkImport', () => {
         newContentPlugins: {},
         updatedContentPlugins: {},
         assetMap: {},
+        newAssetIds: [],
         newTagIds: [],
         contentJson: { course: {} },
         idMap: {},
@@ -438,10 +439,27 @@ describe('AdaptFrameworkImport', () => {
         assetMap: {
           'course/en/assets/logo.png': 'a1',
           'course/en/assets/bg.jpg': 'a2'
-        }
+        },
+        newAssetIds: ['a1', 'a2']
       })
       await rollback.call(ctx)
       assert.deepEqual(deleted.sort(), ['a1', 'a2'])
+    })
+
+    it('should not delete de-duplicated assets that point to pre-existing records', async () => {
+      const deleted = []
+      const ctx = makeRollbackCtx({
+        assets: {
+          delete: async ({ _id }) => deleted.push(_id)
+        },
+        assetMap: {
+          'course/en/assets/new.png': 'a1',
+          'course/en/assets/existing.png': 'a2-existing'
+        },
+        newAssetIds: ['a1']
+      })
+      await rollback.call(ctx)
+      assert.deepEqual(deleted, ['a1'])
     })
 
     it('should delete course content on rollback', async () => {
@@ -499,7 +517,8 @@ describe('AdaptFrameworkImport', () => {
           'path/a.png': 'a1',
           'path/b.png': 'a2',
           'path/c.png': 'a3'
-        }
+        },
+        newAssetIds: ['a1', 'a2', 'a3']
       })
       await rollback.call(ctx)
       assert.deepEqual(deleted.sort(), ['a2', 'a3'])


### PR DESCRIPTION
### Fix
- On rollback after a failed import, only delete assets that the import actually inserted. Assets that were de-duplicated to pre-existing records (the `DUPLICATE_ASSET` path in `importCourseAssets`) are no longer passed to `assets.delete`, which prevents the noisy `RESOURCE_IN_USE` warnings observed when those assets are still referenced by other courses.

### Testing
- [ ] Trigger a failed import that includes at least one asset matching an existing record (same hash) and at least one new asset; confirm rollback logs no `RESOURCE_IN_USE` warnings, the existing asset survives, and the newly inserted asset is removed.
- [ ] Trigger a failed import containing only newly inserted assets; confirm all are removed on rollback (regression check).