### PR TITLE
New: Grant content access via shared user groups

### DIFF
--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -329,7 +329,7 @@ class AdaptFrameworkModule extends AbstractModule {
    */
   async onContentAccessQueryHook (req) {
     if (req.apiData.query._type !== 'course') return
-    applyContentAccessFilter(req.apiData.query, req.auth.user._id.toString())
+    applyContentAccessFilter(req.apiData.query, req.auth.user._id.toString(), req.auth.user.userGroups)
   }
 
   /**
@@ -351,7 +351,12 @@ class AdaptFrameworkModule extends AbstractModule {
     }
     const shareWithUsers = course._shareWithUsers?.map(id => id.toString()) ?? []
     const userId = req.auth.user._id.toString()
-    return course.createdBy.toString() === userId || course._isShared || shareWithUsers.includes(userId)
+    const userGroups = (req.auth.user.userGroups ?? []).map(id => id.toString())
+    const courseGroups = (course.userGroups ?? []).map(id => id.toString())
+    return course.createdBy.toString() === userId ||
+      course._isShared ||
+      shareWithUsers.includes(userId) ||
+      courseGroups.some(g => userGroups.includes(g))
   }
 
   /**

--- a/lib/utils/applyContentAccessFilter.js
+++ b/lib/utils/applyContentAccessFilter.js
@@ -1,18 +1,24 @@
 /**
  * Mutates a mongo content query so it only matches courses the given user can access:
- * owned by them, marked public via `_isShared`, or in `_shareWithUsers`. Combines safely
- * with an existing `$or` (e.g. from search) by lifting both into `$and`.
+ * owned by them, marked public via `_isShared`, in `_shareWithUsers`, or shared with one
+ * of the user's groups (`userGroups`). All are additive grants — sharing a course via any
+ * dimension widens access. Combines safely with an existing `$or` (e.g. from search) by
+ * lifting both into `$and`.
  * @param {object} query The mongo query object to mutate
  * @param {string} userId The user's `_id` (already coerced to string)
+ * @param {Array} [userGroups] The user's group ids; adds a group-sharing grant when present
  * @memberof adaptframework
  */
-export function applyContentAccessFilter (query, userId) {
+export function applyContentAccessFilter (query, userId, userGroups = []) {
   if (!userId) return
   const clauses = [
     { createdBy: userId },
     { _isShared: true },
     { _shareWithUsers: userId }
   ]
+  // a course shared with any group the user belongs to (optional dimension —
+  // only present when the usergroups module is in use)
+  if (userGroups?.length) clauses.push({ userGroups: { $in: userGroups } })
   if (query.$or) {
     query.$and = [
       ...(query.$and ?? []),

--- a/tests/utils-applyContentAccessFilter.spec.js
+++ b/tests/utils-applyContentAccessFilter.spec.js
@@ -19,6 +19,24 @@ describe('applyContentAccessFilter()', () => {
     ])
   })
 
+  it('should add a group-sharing grant when the user has groups', () => {
+    const query = { _type: 'course' }
+    applyContentAccessFilter(query, 'user1', ['g1', 'g2'])
+    assert.deepEqual(query.$or, [
+      { createdBy: 'user1' },
+      { _isShared: true },
+      { _shareWithUsers: 'user1' },
+      { userGroups: { $in: ['g1', 'g2'] } }
+    ])
+  })
+
+  it('should not add a group grant when the user has no groups', () => {
+    const query = { _type: 'course' }
+    applyContentAccessFilter(query, 'user1', [])
+    assert.equal(query.$or.length, 3)
+    assert.ok(!query.$or.some(c => c.userGroups))
+  })
+
   it('should preserve an existing $or by lifting both into $and', () => {
     const query = { $or: [{ title: 'foo' }] }
     applyContentAccessFilter(query, 'user1')


### PR DESCRIPTION
### Fixes #209

### New
- Content access now treats a course's `userGroups` as an additive sharing dimension: a user may access a course if they own it, it's `_isShared`, they're in `_shareWithUsers`, **or** they belong to one of the course's `userGroups`. Applied in both the query-level filter (`applyContentAccessFilter`) and the per-item check (`checkContentAccess`).
- Additive only — group sharing widens access and leaves `_isShared`/`_shareWithUsers` behaviour unchanged. No-op when the user has no groups, so there is no behaviour change without the usergroups module.

### Testing
- Extended `applyContentAccessFilter` unit tests (group grant present / absent); suite green.