### PR TITLE
Fix: guard asset tag lookup against orphaned tag refs

### DIFF
--- a/lib/AdaptFrameworkBuild.js
+++ b/lib/AdaptFrameworkBuild.js
@@ -327,14 +327,14 @@ class AdaptFrameworkBuild {
 
     const usedTagIds = new Set(usedAssets.reduce((m, a) => [...m, ...(a.tags ?? [])], []))
     const usedTags = await tags.find({ _id: { $in: [...usedTagIds] } })
-    const tagTitleLookup = t => usedTags.find(u => u._id.toString() === t.toString()).title
+    const tagTitleLookup = t => usedTags.find(u => u._id.toString() === t.toString())?.title
 
     const idMap = {}
     const assetDocs = []
     const courseDir = this.courseData.course.dir
 
     await Promise.all(usedAssets.map(async a => {
-      assetDocs.push({ ...a, tags: a?.tags?.map(tagTitleLookup) })
+      assetDocs.push({ ...a, tags: a?.tags?.map(tagTitleLookup).filter(Boolean) })
       if (!idMap[a._id]) idMap[a._id] = a.url ? a.url : path.join(courseDir, 'assets', a.path)
     }))
     this.assetData = { dir: courseDir, fileName: 'assets.json', idMap, data: assetDocs }


### PR DESCRIPTION
### Fixes #212

### Fix

- `AdaptFrameworkBuild.loadAssetData` crashed with `Cannot read properties of undefined (reading 'title')` when an asset's `tags` array referenced a tag `_id` not present in the `tags` collection. `usedTags.find(...)` returned `undefined` and `.title` threw, aborting the whole preview/publish build.
- Orphaned tag references arise on re-import: assets dedup by content hash and persist, while tag documents are deleted and recreated with fresh `_id`s each run, so the assets' `tags` arrays dangle.
- Guard the lookup with optional chaining (`?.title`) and drop misses (`.filter(Boolean)`) so a missing tag no longer crashes the build and is simply omitted from the asset's tag titles.

### Testing

- `npx standard lib/AdaptFrameworkBuild.js` passes.
- Verified against a live affected course (25 of 32 tagged assets referencing orphaned tags): build previously threw at the first orphan; with the guard the lookup skips missing tags and the build proceeds.

### Note

This is the build-robustness half. The underlying data-integrity cause (re-import leaving stale `tags` refs while tags are regenerated) should be fixed in `AdaptFrameworkImport` by remapping/pruning asset tag references on re-import; tracked in #212 as follow-up. Same re-import-integrity family as #200.

---

Posted via collaboration with Claude Code