### PR TITLE
Fix: strip derived _assetIds cache from build output (fixes #200)

### DIFF
--- a/lib/AdaptFrameworkBuild.js
+++ b/lib/AdaptFrameworkBuild.js
@@ -412,8 +412,11 @@ class AdaptFrameworkBuild {
    */
   async transformContentItems (items) {
     items.forEach(i => {
+      // _assetIds is a derived server cache, not framework content; drop it so the
+      // asset-id->path replace below can't corrupt it and break re-import (#200)
+      delete i._assetIds
       // slot any _friendlyIds into the _id field
-      ['_courseId', '_parentId'].forEach(k => {
+      ;['_courseId', '_parentId'].forEach(k => {
         i[k] = this.idMap[i[k]] || i[k]
       })
       if (i._friendlyId) {


### PR DESCRIPTION
### Fixes #200

### Fix

- Export was serialising the derived `_assetIds` cache into content JSON as asset *paths* instead of ObjectIds. `transformContentItems` blind-replaces every asset `_id` with its relative path across the whole stringified content item, which also rewrote the `_assetIds` array (e.g. `["course/en/assets/69fb…svg"]`). On re-import, `importContentObject`'s recompute guard sees a populated `_assetIds` and skips recomputation, so builds later try to parse the path strings as ObjectIds and throw `INVALID_OBJECTID`.
- `_assetIds` is a server-side derived cache (`ContentModule.computeAssetIds`) and is not part of the framework content schema, so it is now deleted before serialisation — it can neither be corrupted by the path replace nor survive into an export.

### Testing

- `npx standard` passes.
- Verified `_assetIds` is the only derived asset-id cache affected (every other asset-id field is a genuine reference that should be path-rewritten), and that the transformed items are build-local copies, so the delete mutates nothing persisted.
- A roundtrip integration test (export → re-import) is proposed in `adapt-security/adapt-authoring-integration-tests` (asserts the exported content no longer carries `_assetIds`).
