### PR TITLE
New: Add importProgressHook for import progress reporting

### DIFF
--- a/docs/building-courses.md
+++ b/docs/building-courses.md
@@ -180,6 +180,35 @@ deep clone), so an observer can:
 `postBuildHook` fires after the output (and zip) is in place but before the response, with
 the same instance — `builder.location` is then populated.
 
+## Extension point: `importProgressHook`
+
+`AdaptFrameworkModule` exposes `importProgressHook`, invoked repeatedly while a course
+imports so consumers can surface progress. It is **transport-agnostic** — the framework
+emits plain progress objects and never depends on any particular delivery mechanism;
+relaying them (e.g. over a websocket) is the consumer's job. The module wires it to fire
+from inside `AdaptFrameworkImport`; observers receive the live importer and a progress
+object:
+
+```javascript
+const framework = await this.app.waitForModule('adaptframework')
+
+framework.importProgressHook.tap((importer, progress) => {
+  // importer.importToken — the opaque correlation id passed to POST /import
+  // progress.phase       — the current phase key (e.g. 'importCourseAssets')
+  // progress.step / progress.totalSteps — phase position in the run
+  // progress.current / progress.total   — per-item count within a heavy phase
+})
+```
+
+Two kinds of event are emitted: a **phase** event (`{ phase, step, totalSteps }`) before
+each enabled phase runs, and **per-item** events (`{ phase, current, total }`) within the
+heavy phases (`importCourseAssets`, `importCourseData`). Observers should treat the payload
+as additive — not every event carries every field.
+
+`importToken` is an opaque correlation id: pass it in the `POST /import` body and read it
+off the importer here to attribute progress to a specific import (e.g. to pick a websocket
+room). It has no meaning to the framework itself.
+
 ## Configuration
 
 From `conf/config.schema.json`, namespaced `adapt-authoring-adaptframework.*`:

--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -215,7 +215,7 @@ class AdaptFrameworkImport {
      */
     this.postImportHook = new Hook()
     /**
-     * Invoked repeatedly during import with a progress object ({ phase, step, totalSteps, current, total }). Bridged to the module-level importProgressHook.
+     * Per-import progress signal; bridged to the module-level importProgressHook.
      */
     this.importProgressHook = new Hook()
 

--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -73,11 +73,12 @@ class AdaptFrameworkImport {
    * @property {Boolean} importPlugins Whether content plugins not present on the server will be installed (default: true)
    * @property {Boolean} updatePlugins Whether server content plugins should be updated if newer versions exist in the import course (default: false)
    * @property {Boolean} removeSource Whether import files should be removed after the process has completed (default: true)
+   * @property {String} importToken Opaque correlation id passed through to importProgressHook observers, so a consumer can attribute progress to this import
    *
    * @constructor
    * @param {AdaptFrameworkImportOptions} options
    */
-  constructor ({ importPath, userId, language, assetFolders, tags, isDryRun = false, importContent = true, importPlugins = true, migrateContent = true, updatePlugins = false, removeSource = true }) {
+  constructor ({ importPath, userId, language, assetFolders, tags, isDryRun = false, importContent = true, importPlugins = true, migrateContent = true, updatePlugins = false, removeSource = true, importToken }) {
     const e = App.instance.errors.INVALID_PARAMS
     if (!importPath) throw e.setData({ params: ['importPath'] })
     if (!userId) throw e.setData({ params: ['userId'] })
@@ -165,6 +166,11 @@ class AdaptFrameworkImport {
      */
     this.userId = userId
     /**
+     * Opaque correlation id for this import, surfaced to importProgressHook observers
+     * @type {String}
+     */
+    this.importToken = importToken
+    /**
      * Array of tag IDs created during import for rollback
      * @type {Array<String>}
      */
@@ -208,6 +214,10 @@ class AdaptFrameworkImport {
      * Invoked once the import process has completed
      */
     this.postImportHook = new Hook()
+    /**
+     * Invoked repeatedly during import with a progress object ({ phase, step, totalSteps, current, total }). Bridged to the module-level importProgressHook.
+     */
+    this.importProgressHook = new Hook()
 
     /**
      * plugins on import that are of a lower version than the installed version
@@ -274,8 +284,11 @@ class AdaptFrameworkImport {
         [this.importCourseData, !isDryRun && importContent],
         [this.generateSummary]
       ]
-      for (const task of tasks) {
-        if (task.length < 2 || task[1]) await task[0].call(this)
+      const enabled = tasks.filter(task => task.length < 2 || task[1])
+      for (let i = 0; i < enabled.length; i++) {
+        const fn = enabled[i][0]
+        await this.importProgressHook.invoke(this, { phase: fn.name || 'preImport', step: i + 1, totalSteps: enabled.length })
+        await fn.call(this)
       }
       await this.postImportHook.invoke(this)
     } catch (e) {
@@ -619,6 +632,7 @@ class AdaptFrameworkImport {
         }
       }
       imagesImported++
+      await this.importProgressHook.invoke(this, { phase: 'importCourseAssets', current: imagesImported, total: this.assetData.length })
     }))
     log('debug', 'imported course assets successfully')
     this.statusReport.info.push({ code: 'ASSETS_IMPORTED_SUCCESSFULLY', data: { count: imagesImported } })
@@ -762,6 +776,8 @@ class AdaptFrameworkImport {
     }
     const { sorted, hierarchy } = await this.getSortedData()
     const errors = []
+    const total = sorted.reduce((n, ids) => n + ids.length, 0)
+    let current = 0
 
     for (const ids of sorted) {
       for (const _id of ids) {
@@ -774,6 +790,7 @@ class AdaptFrameworkImport {
         } catch (e) {
           errors.push(formatError(e))
         }
+        await this.importProgressHook.invoke(this, { phase: 'importCourseData', current: ++current, total })
       }
     }
     if (errors.length) throw App.instance.errors.FW_IMPORT_CONTENT_FAILED.setData({ errors })

--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -44,6 +44,11 @@ class AdaptFrameworkModule extends AbstractModule {
      */
     this.postImportHook = new Hook()
     /**
+     * Invoked repeatedly during an import to report progress. Observers receive the AdaptFrameworkImport instance and a progress object ({ phase, step, totalSteps, current, total }). Transport-agnostic — consumers relay it as needed (e.g. over a websocket).
+     * @type {Hook}
+     */
+    this.importProgressHook = new Hook()
+    /**
      * Invoked prior to a course being built. The AdaptFrameworkBuild instance is passed to any observers.
      * @type {Hook}
      */
@@ -432,6 +437,7 @@ class AdaptFrameworkModule extends AbstractModule {
     const importer = new AdaptFrameworkImport(options)
     importer.preImportHook.tap(() => this.preImportHook.invoke(importer))
     importer.postImportHook.tap(() => this.postImportHook.invoke(importer))
+    importer.importProgressHook.tap(progress => this.importProgressHook.invoke(importer, progress))
     if (this.importHook.hasObservers) {
       return this.importHook.invoke(async () => importer.import(), importer)
     }

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -110,7 +110,8 @@ export async function importHandler (req, res, next) {
       importContent: toBoolean(req.body.importContent),
       importPlugins: toBoolean(req.body.importPlugins),
       migrateContent: toBoolean(req.body.migrateContent),
-      updatePlugins: toBoolean(req.body.updatePlugins)
+      updatePlugins: toBoolean(req.body.updatePlugins),
+      importToken: req.body.importToken
     })
     res.json(importer.summary)
   } catch (e) {

--- a/routes.json
+++ b/routes.json
@@ -68,7 +68,8 @@
                     "isDryRun": { "type": "Boolean", "default": false },
                     "importContent": { "type": "Boolean", "default": true },
                     "importPlugins": { "type": "Boolean", "default": true },
-                    "updatePlugins": { "type": "Boolean", "default": false }
+                    "updatePlugins": { "type": "Boolean", "default": false },
+                    "importToken": { "type": "String" }
                   }
                 }
               }


### PR DESCRIPTION
### New
- Add a generic, transport-agnostic `importProgressHook` to `AdaptFrameworkModule`, bridged from `AdaptFrameworkImport` (mirrors the existing `preImportHook`/`postImportHook` wiring).
- Emit progress during import:
  - a **phase** event (`{ phase, step, totalSteps }`) before each enabled phase in the import task loop, and
  - **per-item** events (`{ phase, current, total }`) within the heavy phases `importCourseAssets` and `importCourseData`.
- Thread an opaque `importToken` correlation id through `POST /import` → `importCourse()` → the importer (exposed as `importer.importToken`), so a consumer can attribute progress to a specific import (e.g. pick a websocket room). It has no meaning to the framework itself.
- Document the new seam in `docs/building-courses.md`.

The framework emits plain progress objects and depends on no particular delivery mechanism; relaying them (e.g. over a websocket) is left to consumer modules.

### Testing
- `npm test` — all 38 tests pass.
- `npx standard` — clean.