### PR TITLE
Update: Add pluginUpdatePolicy and fix plugin update reporting/execution

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -5,7 +5,7 @@ import { glob } from 'glob'
 import path from 'upath'
 import semver from 'semver'
 import { unzip } from 'zipper'
-import { log, logDir, getImportSummary, getImportContentCounts, readFrameworkPluginVersions, collectMigrationScripts, runContentMigration, reconcileAssetTags } from './utils.js'
+import { log, logDir, getImportSummary, getImportContentCounts, readFrameworkPluginVersions, collectMigrationScripts, runContentMigration, reconcileAssetTags, resolvePluginAction, resolvePluginUpdatePolicy } from './utils.js'
 
 import ComponentTransform from './migrations/component.js'
 import ConfigTransform from './migrations/config.js'
@@ -71,14 +71,15 @@ class AdaptFrameworkImport {
    * @property {Boolean} isDryRun Will perform a non-modifying import process and report on the changes if run in standard mode
    * @property {Boolean} importContent Whether course content will be imported (default: true)
    * @property {Boolean} importPlugins Whether content plugins not present on the server will be installed (default: true)
-   * @property {Boolean} updatePlugins Whether server content plugins should be updated if newer versions exist in the import course (default: false)
+   * @property {Boolean} updatePlugins Deprecated: use pluginUpdatePolicy. true maps to 'all', explicit false maps to 'none'.
+   * @property {String} pluginUpdatePolicy Which installed plugins may be updated to a newer version found in the import: 'none' (update nothing), 'custom' (custom/local plugins only — default), 'all' (custom + managed)
    * @property {Boolean} removeSource Whether import files should be removed after the process has completed (default: true)
    * @property {String} importToken Opaque correlation id passed through to importProgressHook observers, so a consumer can attribute progress to this import
    *
    * @constructor
    * @param {AdaptFrameworkImportOptions} options
    */
-  constructor ({ importPath, userId, language, assetFolders, tags, isDryRun = false, importContent = true, importPlugins = true, migrateContent = true, updatePlugins = false, removeSource = true, importToken }) {
+  constructor ({ importPath, userId, language, assetFolders, tags, isDryRun = false, importContent = true, importPlugins = true, migrateContent = true, updatePlugins, pluginUpdatePolicy, removeSource = true, importToken }) {
     const e = App.instance.errors.INVALID_PARAMS
     if (!importPath) throw e.setData({ params: ['importPath'] })
     if (!userId) throw e.setData({ params: ['userId'] })
@@ -203,7 +204,7 @@ class AdaptFrameworkImport {
       importContent,
       importPlugins,
       migrateContent,
-      updatePlugins,
+      pluginUpdatePolicy: resolvePluginUpdatePolicy(pluginUpdatePolicy, updatePlugins),
       removeSource
     }
     /**
@@ -657,9 +658,10 @@ class AdaptFrameworkImport {
     }
     const pluginsToInstall = []
     const pluginsToUpdate = []
+    const policy = this.settings.pluginUpdatePolicy
 
-    let managedPluginUpdateBlocked = false
-    Object.keys(this.usedContentPlugins).forEach(p => {
+    let managedUpdatesAvailable = false
+    for (const p of Object.keys(this.usedContentPlugins)) {
       const { name: pluginName } = this.usedContentPlugins[p]
       const installedP = this.installedPlugins[pluginName]
       let { version: importVersion } = this.usedContentPlugins[p]
@@ -670,41 +672,64 @@ class AdaptFrameworkImport {
         this.statusReport.warn.push({ code: 'INVALID_PLUGIN_VERSION', data: { name: p, importVersion } })
         importVersion = '0.0.0' // set to a valid version to allow the other logic to run
       }
-      if (!installedP) {
-        return pluginsToInstall.push(p)
+      const installedVersion = installedP?.version
+      const { action, reason } = resolvePluginAction({
+        installedVersion,
+        importVersion,
+        isLocalInstall: installedP?.isLocalInstall,
+        policy
+      })
+      switch (action) {
+        case 'install':
+          pluginsToInstall.push(p)
+          break
+        case 'update':
+          pluginsToUpdate.push(p)
+          break
+        case 'migrate':
+          this.statusReport.info.push({ code: 'PLUGIN_INSTALL_MIGRATING', data: { name: p, installedVersion, importVersion } })
+          log('debug', `migrating '${p}@${importVersion}' during import, installed version is newer (${installedVersion})`)
+          this.pluginsToMigrate.push(p)
+          break
+        case 'skip':
+          if (reason === 'NO_CHANGE') {
+            this.statusReport.info.push({ code: 'PLUGIN_INSTALL_NOT_NEWER', data: { name: p, installedVersion, importVersion } })
+          } else if (reason === 'MANAGED_UPDATE_SKIPPED') {
+            managedUpdatesAvailable = true
+            this.statusReport.warn.push({ code: 'MANAGED_PLUGIN_INSTALL_SKIPPED', data: { name: p, installedVersion, importVersion } })
+            log('debug', `not updating managed plugin '${p}@${importVersion}' (policy: ${policy}, installed: ${installedVersion})`)
+          } else { // CUSTOM_UPDATE_DISABLED — policy 'none'
+            this.statusReport.info.push({ code: 'PLUGIN_UPDATE_DISABLED', data: { name: p, installedVersion, importVersion } })
+          }
+          break
       }
-      const { version: installedVersion, isLocalInstall } = installedP
-      if (semver.lt(importVersion, installedVersion)) {
-        this.statusReport.info.push({ code: 'PLUGIN_INSTALL_MIGRATING', data: { name: p, installedVersion, importVersion } })
-        log('debug', `migrating '${p}@${importVersion}' during import, installed version is newer (${installedVersion})`)
-        this.pluginsToMigrate.push(p)
-        return
-      }
-      if (!this.settings.updatePlugins) {
-        if (!isLocalInstall && semver.gt(importVersion, installedVersion)) managedPluginUpdateBlocked = true
-        return
-      }
-      if (semver.eq(importVersion, installedVersion)) {
-        this.statusReport.info.push({ code: 'PLUGIN_INSTALL_NOT_NEWER', data: { name: p, installedVersion, importVersion } })
-        log('debug', `not updating '${p}@${importVersion}' during import, installed version is equal to (${installedVersion})`)
-        return
-      }
-      if (!isLocalInstall) {
-        this.statusReport.warn.push({ code: 'MANAGED_PLUGIN_INSTALL_SKIPPED', data: { name: p, installedVersion, importVersion } })
-        log('debug', `cannot update '${p}' during import, plugin managed via UI`)
-      }
-      pluginsToUpdate.push(p)
-    })
-    if (managedPluginUpdateBlocked) {
+    }
+    if (managedUpdatesAvailable) {
       this.statusReport.warn.push({ code: 'MANAGED_PLUGIN_UPDATE_DISABLED' })
     }
-    if (pluginsToInstall.length) {
-      if (!this.settings.importPlugins) {
-        if (this.settings.isDryRun) return this.statusReport.error.push({ code: 'MISSING_PLUGINS', data: pluginsToInstall })
+    // Plugins are global: surface which other courses an in-place update affects.
+    for (const p of pluginsToUpdate) {
+      const { name: pluginName } = this.usedContentPlugins[p]
+      const courses = await this.coursesUsingPlugin(pluginName)
+      if (courses.length) {
+        this.statusReport.warn.push({
+          code: 'PLUGIN_UPDATE_AFFECTS_COURSES',
+          data: { name: p, from: this.installedPlugins[pluginName]?.version, to: this.usedContentPlugins[p].version, courses }
+        })
+      }
+    }
+    const allPlugins = [...pluginsToInstall, ...pluginsToUpdate]
+    if (pluginsToInstall.length && !this.settings.importPlugins) {
+      // genuinely missing plugins can't be satisfied without importPlugins
+      if (this.settings.isDryRun) {
+        this.statusReport.error.push({ code: 'MISSING_PLUGINS', data: pluginsToInstall })
+      } else {
         throw App.instance.errors.FW_IMPORT_MISSING_PLUGINS
           .setData({ plugins: pluginsToInstall.join(', ') })
       }
-      const allPlugins = [...pluginsToInstall, ...pluginsToUpdate]
+    }
+    // install/update runs whenever there's anything to do AND plugin writes are permitted
+    if (allPlugins.length && this.settings.importPlugins) {
       // pre-process: store update metadata and fix missing targetAttributes
       for (const p of allPlugins) {
         const isUpdate = pluginsToUpdate.includes(p)
@@ -746,6 +771,24 @@ class AdaptFrameworkImport {
       return { ...m, [v.targetAttribute.slice(1)]: v.name }
     }, {})
     log('debug', 'imported course plugins successfully')
+  }
+
+  /**
+   * Returns the _courseIds of other courses whose config enables the named plugin.
+   * Used to report the blast radius of an in-place plugin update (plugins are global).
+   * The course being imported is not yet in the database at this point, so it is
+   * implicitly excluded.
+   * @param {String} name Plugin name
+   * @return {Promise<Array<String>>} Affected course ids
+   */
+  async coursesUsingPlugin (name) {
+    try {
+      const configs = await this.content.find({ _type: 'config', _enabledPlugins: name })
+      return configs.map(c => c._courseId?.toString()).filter(Boolean)
+    } catch (e) {
+      log('warn', `failed to check courses using plugin '${name}'`, e)
+      return []
+    }
   }
 
   /**

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -110,7 +110,9 @@ export async function importHandler (req, res, next) {
       importContent: toBoolean(req.body.importContent),
       importPlugins: toBoolean(req.body.importPlugins),
       migrateContent: toBoolean(req.body.migrateContent),
-      updatePlugins: toBoolean(req.body.updatePlugins),
+      // updatePlugins kept for backwards compatibility; only forwarded when present so an absent value falls through to the default policy
+      updatePlugins: req.body.updatePlugins === undefined ? undefined : toBoolean(req.body.updatePlugins),
+      pluginUpdatePolicy: req.body.pluginUpdatePolicy,
       importToken: req.body.importToken
     })
     res.json(importer.summary)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,8 @@
 export { applyContentAccessFilter } from './utils/applyContentAccessFilter.js'
 export { inferBuildAction } from './utils/inferBuildAction.js'
 export { getPluginUpdateStatus } from './utils/getPluginUpdateStatus.js'
+export { resolvePluginAction } from './utils/resolvePluginAction.js'
+export { resolvePluginUpdatePolicy } from './utils/resolvePluginUpdatePolicy.js'
 export { getImportContentCounts } from './utils/getImportContentCounts.js'
 export { reconcileAssetTags } from './utils/reconcileAssetTags.js'
 export { log, logDir, logMemory } from './utils/log.js'

--- a/lib/utils/getImportSummary.js
+++ b/lib/utils/getImportSummary.js
@@ -30,7 +30,7 @@ export async function getImportSummary (importer) {
     usedContentPlugins: usedPlugins,
     newContentPlugins: newPlugins,
     statusReport,
-    settings: { updatePlugins }
+    settings: { pluginUpdatePolicy }
   } = importer
   const versions = [
     { name: fwName, versions: [framework.version, fwVersion] },
@@ -41,7 +41,7 @@ export async function getImportSummary (importer) {
     const versions = meta.versions ?? [p?.version, meta.version]
     return {
       name: meta.name,
-      status: getPluginUpdateStatus(versions, p?.isLocalInstall, updatePlugins),
+      status: getPluginUpdateStatus(versions, p?.isLocalInstall, pluginUpdatePolicy),
       versions
     }
   })

--- a/lib/utils/getPluginUpdateStatus.js
+++ b/lib/utils/getPluginUpdateStatus.js
@@ -1,20 +1,24 @@
-import semver from 'semver'
+import { resolvePluginAction } from './resolvePluginAction.js'
+
+const ACTION_TO_STATUS = {
+  invalid: 'INVALID',
+  install: 'INSTALLED',
+  migrate: 'OLDER',
+  update: 'UPDATED'
+}
 
 /**
- * Determines the update status code for a plugin based on version comparison
+ * Maps the resolved import action for a plugin to a display status code.
+ * Thin label-mapper over resolvePluginAction so the status report and the
+ * import executor always agree.
  * @param {Array} versions Tuple of [installedVersion, importVersion]
- * @param {Boolean} isLocalInstall Whether the plugin is a local install
- * @param {Boolean} updatePlugins Whether plugin updates are enabled
- * @returns {String} The update status code
+ * @param {Boolean} isLocalInstall Whether the installed plugin is a custom (local) install
+ * @param {'none'|'custom'|'all'} policy The plugin update policy
+ * @returns {String} 'INVALID' | 'INSTALLED' | 'OLDER' | 'NO_CHANGE' | 'UPDATED' | 'UPDATE_BLOCKED'
  */
-export function getPluginUpdateStatus (versions, isLocalInstall, updatePlugins) {
+export function getPluginUpdateStatus (versions, isLocalInstall, policy) {
   const [installedVersion, importVersion] = versions
-  if (!semver.valid(importVersion)) return 'INVALID'
-  if (!installedVersion) return 'INSTALLED'
-  if (semver.lt(importVersion, installedVersion)) return 'OLDER'
-  if (semver.gt(importVersion, installedVersion)) {
-    if (!updatePlugins && !isLocalInstall) return 'UPDATE_BLOCKED'
-    return 'UPDATED'
-  }
-  return 'NO_CHANGE'
+  const { action, reason } = resolvePluginAction({ installedVersion, importVersion, isLocalInstall, policy })
+  if (action === 'skip') return reason === 'NO_CHANGE' ? 'NO_CHANGE' : 'UPDATE_BLOCKED'
+  return ACTION_TO_STATUS[action]
 }

--- a/lib/utils/resolvePluginAction.js
+++ b/lib/utils/resolvePluginAction.js
@@ -1,0 +1,32 @@
+import semver from 'semver'
+
+/**
+ * Single source of truth for what a course import should do with one plugin.
+ * Pure: no app state, no side effects — so the status report and the executor
+ * can both derive from it and never disagree.
+ *
+ * Plugin classes (see contentplugin `isLocalInstall`):
+ * - custom  = local install (uploaded with a course / local path)
+ * - managed = installed by name from the registry/framework manifest
+ *
+ * @param {Object} options
+ * @param {String} [options.installedVersion] Installed version, falsy if not installed
+ * @param {String} options.importVersion Version present in the import
+ * @param {Boolean} [options.isLocalInstall] Whether the installed plugin is a custom (local) install
+ * @param {'none'|'custom'|'all'} [options.policy='custom'] Update policy
+ * @returns {{ action: String, reason: String }}
+ *   action: 'install' | 'update' | 'migrate' | 'skip' | 'invalid'
+ */
+export function resolvePluginAction ({ installedVersion, importVersion, isLocalInstall, policy = 'custom' }) {
+  if (!semver.valid(importVersion)) return { action: 'invalid', reason: 'INVALID_IMPORT_VERSION' }
+  if (!installedVersion) return { action: 'install', reason: 'NOT_INSTALLED' }
+  if (semver.lt(importVersion, installedVersion)) return { action: 'migrate', reason: 'IMPORT_OLDER' }
+  if (semver.eq(importVersion, installedVersion)) return { action: 'skip', reason: 'NO_CHANGE' }
+  // import is strictly newer than installed
+  const mayUpdate = policy === 'all' || (policy === 'custom' && isLocalInstall === true)
+  if (mayUpdate) return { action: 'update', reason: isLocalInstall ? 'CUSTOM_NEWER' : 'MANAGED_NEWER' }
+  return {
+    action: 'skip',
+    reason: isLocalInstall ? 'CUSTOM_UPDATE_DISABLED' : 'MANAGED_UPDATE_SKIPPED'
+  }
+}

--- a/lib/utils/resolvePluginUpdatePolicy.js
+++ b/lib/utils/resolvePluginUpdatePolicy.js
@@ -1,0 +1,19 @@
+export const PLUGIN_UPDATE_POLICIES = ['none', 'custom', 'all']
+
+/**
+ * Resolves the effective plugin update policy, mapping the legacy `updatePlugins`
+ * boolean for backwards compatibility.
+ * - an explicit valid `pluginUpdatePolicy` always wins
+ * - `updatePlugins: true`  -> 'all'
+ * - `updatePlugins: false` (explicitly passed) -> 'none'
+ * - neither provided -> 'custom' (default)
+ * @param {String} [pluginUpdatePolicy] One of 'none' | 'custom' | 'all'
+ * @param {Boolean} [updatePlugins] Legacy boolean
+ * @returns {'none'|'custom'|'all'}
+ */
+export function resolvePluginUpdatePolicy (pluginUpdatePolicy, updatePlugins) {
+  if (PLUGIN_UPDATE_POLICIES.includes(pluginUpdatePolicy)) return pluginUpdatePolicy
+  if (updatePlugins === true) return 'all'
+  if (updatePlugins === false) return 'none'
+  return 'custom'
+}

--- a/tests/utils-getPluginUpdateStatus.spec.js
+++ b/tests/utils-getPluginUpdateStatus.spec.js
@@ -5,30 +5,34 @@ import { getPluginUpdateStatus } from '../lib/utils/getPluginUpdateStatus.js'
 
 describe('getPluginUpdateStatus()', () => {
   it('should return "INVALID" for an invalid import version', () => {
-    assert.equal(getPluginUpdateStatus(['1.0.0', 'not-valid'], false, false), 'INVALID')
+    assert.equal(getPluginUpdateStatus(['1.0.0', 'not-valid'], false, 'all'), 'INVALID')
   })
 
   it('should return "INSTALLED" when no installed version exists', () => {
-    assert.equal(getPluginUpdateStatus([undefined, '1.0.0'], false, false), 'INSTALLED')
+    assert.equal(getPluginUpdateStatus([undefined, '1.0.0'], false, 'none'), 'INSTALLED')
   })
 
   it('should return "OLDER" when import version is older', () => {
-    assert.equal(getPluginUpdateStatus(['2.0.0', '1.0.0'], false, false), 'OLDER')
+    assert.equal(getPluginUpdateStatus(['2.0.0', '1.0.0'], false, 'all'), 'OLDER')
   })
 
   it('should return "NO_CHANGE" when versions are equal', () => {
-    assert.equal(getPluginUpdateStatus(['1.0.0', '1.0.0'], false, false), 'NO_CHANGE')
+    assert.equal(getPluginUpdateStatus(['1.0.0', '1.0.0'], false, 'all'), 'NO_CHANGE')
   })
 
-  it('should return "UPDATE_BLOCKED" when import is newer but updates not enabled and not local', () => {
-    assert.equal(getPluginUpdateStatus(['1.0.0', '2.0.0'], false, false), 'UPDATE_BLOCKED')
+  it('should return "UPDATED" when import is newer for a custom plugin under the default (custom) policy', () => {
+    assert.equal(getPluginUpdateStatus(['1.0.0', '2.0.0'], true, 'custom'), 'UPDATED')
   })
 
-  it('should return "UPDATED" when import is newer and updates are enabled', () => {
-    assert.equal(getPluginUpdateStatus(['1.0.0', '2.0.0'], false, true), 'UPDATED')
+  it('should return "UPDATE_BLOCKED" for a newer managed plugin under the custom policy', () => {
+    assert.equal(getPluginUpdateStatus(['1.0.0', '2.0.0'], false, 'custom'), 'UPDATE_BLOCKED')
   })
 
-  it('should return "UPDATED" when import is newer and is a local install', () => {
-    assert.equal(getPluginUpdateStatus(['1.0.0', '2.0.0'], true, false), 'UPDATED')
+  it('should return "UPDATE_BLOCKED" for a newer custom plugin under the none policy', () => {
+    assert.equal(getPluginUpdateStatus(['1.0.0', '2.0.0'], true, 'none'), 'UPDATE_BLOCKED')
+  })
+
+  it('should return "UPDATED" for a newer managed plugin only under the all policy', () => {
+    assert.equal(getPluginUpdateStatus(['1.0.0', '2.0.0'], false, 'all'), 'UPDATED')
   })
 })

--- a/tests/utils-resolvePluginAction.spec.js
+++ b/tests/utils-resolvePluginAction.spec.js
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolvePluginAction } from '../lib/utils/resolvePluginAction.js'
+
+describe('resolvePluginAction()', () => {
+  it('should report invalid when the import version is not valid semver', () => {
+    const r = resolvePluginAction({ installedVersion: '1.0.0', importVersion: 'nope', isLocalInstall: true, policy: 'all' })
+    assert.equal(r.action, 'invalid')
+  })
+
+  it('should install when not already installed', () => {
+    const r = resolvePluginAction({ installedVersion: undefined, importVersion: '1.0.0', policy: 'none' })
+    assert.equal(r.action, 'install')
+    assert.equal(r.reason, 'NOT_INSTALLED')
+  })
+
+  it('should migrate (keep installed) when the import is older', () => {
+    const r = resolvePluginAction({ installedVersion: '2.0.0', importVersion: '1.0.0', isLocalInstall: true, policy: 'all' })
+    assert.equal(r.action, 'migrate')
+    assert.equal(r.reason, 'IMPORT_OLDER')
+  })
+
+  it('should skip (no change) when versions are equal', () => {
+    const r = resolvePluginAction({ installedVersion: '1.2.3', importVersion: '1.2.3', isLocalInstall: false, policy: 'all' })
+    assert.equal(r.action, 'skip')
+    assert.equal(r.reason, 'NO_CHANGE')
+  })
+
+  // newer import — the policy matrix
+  const newer = { installedVersion: '1.0.0', importVersion: '2.0.0' }
+  const cases = [
+    { policy: 'none', isLocalInstall: true, action: 'skip', reason: 'CUSTOM_UPDATE_DISABLED' },
+    { policy: 'none', isLocalInstall: false, action: 'skip', reason: 'MANAGED_UPDATE_SKIPPED' },
+    { policy: 'custom', isLocalInstall: true, action: 'update', reason: 'CUSTOM_NEWER' },
+    { policy: 'custom', isLocalInstall: false, action: 'skip', reason: 'MANAGED_UPDATE_SKIPPED' },
+    { policy: 'all', isLocalInstall: true, action: 'update', reason: 'CUSTOM_NEWER' },
+    { policy: 'all', isLocalInstall: false, action: 'update', reason: 'MANAGED_NEWER' }
+  ]
+  for (const c of cases) {
+    it(`newer import: policy=${c.policy} ${c.isLocalInstall ? 'custom' : 'managed'} -> ${c.action}/${c.reason}`, () => {
+      const r = resolvePluginAction({ ...newer, isLocalInstall: c.isLocalInstall, policy: c.policy })
+      assert.equal(r.action, c.action)
+      assert.equal(r.reason, c.reason)
+    })
+  }
+
+  it('should default to the custom policy when none is given', () => {
+    assert.equal(resolvePluginAction({ installedVersion: '1.0.0', importVersion: '2.0.0', isLocalInstall: true }).action, 'update')
+    assert.equal(resolvePluginAction({ installedVersion: '1.0.0', importVersion: '2.0.0', isLocalInstall: false }).action, 'skip')
+  })
+
+  it('should treat a prerelease install as newer than its release base (no downgrade)', () => {
+    const r = resolvePluginAction({ installedVersion: '5.14.4-pr', importVersion: '5.14.3', isLocalInstall: true, policy: 'all' })
+    assert.equal(r.action, 'migrate')
+  })
+})

--- a/tests/utils-resolvePluginUpdatePolicy.spec.js
+++ b/tests/utils-resolvePluginUpdatePolicy.spec.js
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolvePluginUpdatePolicy } from '../lib/utils/resolvePluginUpdatePolicy.js'
+
+describe('resolvePluginUpdatePolicy()', () => {
+  it('should default to "custom" when nothing is provided', () => {
+    assert.equal(resolvePluginUpdatePolicy(undefined, undefined), 'custom')
+  })
+
+  it('should honour an explicit valid policy over the legacy boolean', () => {
+    assert.equal(resolvePluginUpdatePolicy('none', true), 'none')
+    assert.equal(resolvePluginUpdatePolicy('all', false), 'all')
+    assert.equal(resolvePluginUpdatePolicy('custom', true), 'custom')
+  })
+
+  it('should map legacy updatePlugins:true to "all"', () => {
+    assert.equal(resolvePluginUpdatePolicy(undefined, true), 'all')
+  })
+
+  it('should map an explicit updatePlugins:false to "none"', () => {
+    assert.equal(resolvePluginUpdatePolicy(undefined, false), 'none')
+  })
+
+  it('should ignore an invalid policy string and fall back to the legacy/default', () => {
+    assert.equal(resolvePluginUpdatePolicy('bogus', true), 'all')
+    assert.equal(resolvePluginUpdatePolicy('bogus', undefined), 'custom')
+  })
+})


### PR DESCRIPTION
### Fixes #222

### Update
- New `pluginUpdatePolicy: 'none' | 'custom' | 'all'` import setting (default `custom`): update custom (local) plugins upward, leave managed plugins unless `all`. Legacy `updatePlugins` is mapped for compatibility (true→`all`, explicit false→`none`, absent→default).
- Single pure `resolvePluginAction` is the source of truth for the per-plugin decision; `getPluginUpdateStatus` is now a thin mapper over it, so the import **status report and the executor can no longer disagree**.
- In-place updates to a shared (global) plugin now report the other affected courses via `PLUGIN_UPDATE_AFFECTS_COURSES`.

### Fix
- Plugin updates were only applied when at least one plugin was also being **installed** (the install/update block was nested in `if (pluginsToInstall.length)`); update-only imports silently dropped them while still reporting success. Install/update now runs whenever there's anything to install **or** update, with the missing-plugin/`importPlugins` check scoped to actual installs.
- Rollback metadata (`updatedContentPlugins`) is now recorded for every update, not only when an install also occurred.
- Removed the contradictory managed-plugin path that warned "cannot update… managed via UI" and then updated anyway.

### Breaking / behaviour change
- With **no** flag passed, custom plugins now update upward on import (previously nothing updated by default). Tagged `Update` for review — retag `Breaking` if a major bump is preferred. Existing `updatePlugins:false` callers keep "update nothing" (→ `none`).

### Testing
- `tests/utils-resolvePluginAction.spec.js` — table-driven over installed?/older/equal/newer × custom/managed × none/custom/all.
- `tests/utils-resolvePluginUpdatePolicy.spec.js` — legacy-flag compat mapping.
- `tests/utils-getPluginUpdateStatus.spec.js` — updated to policy semantics and asserts alignment with the resolver.
- Full suite: 214 passing; `standard` clean.

### Follow-up (out of scope)
- The UI (`adapt-authoring-ui`) should expose `pluginUpdatePolicy` and migrate off the `updatePlugins` checkbox; until then the new default applies to API callers that omit both fields.