### PR TITLE
Fix: repair import progress hook and emit stable stage ids

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -29,6 +29,20 @@ const ContentMigrations = [
   VanillaBackgroundStylesTransform
 ]
 
+const PROGRESS_STAGES = {
+  prepare: { id: 'unpacking', labelKey: 'app.importstepunpacking' },
+  loadAssetData: { id: 'unpacking', labelKey: 'app.importstepunpacking' },
+  loadPluginData: { id: 'unpacking', labelKey: 'app.importstepunpacking' },
+  preImport: { id: 'unpacking', labelKey: 'app.importstepunpacking' },
+  importTags: { id: 'unpacking', labelKey: 'app.importstepunpacking' },
+  importCourseAssets: { id: 'assets', labelKey: 'app.importstepassets' },
+  importCoursePlugins: { id: 'plugins', labelKey: 'app.importstepplugins' },
+  loadCourseData: { id: 'structure', labelKey: 'app.importstepstructure' },
+  migrateCourseData: { id: 'migrate', labelKey: 'app.importstepmigrating' },
+  importCourseData: { id: 'content', labelKey: 'app.importstepcontent' },
+  generateSummary: { id: 'finish', labelKey: 'app.importstepfinishing' }
+}
+
 /**
  * Handles the Adapt framework import process
  * @memberof adaptframework
@@ -288,7 +302,8 @@ class AdaptFrameworkImport {
       const enabled = tasks.filter(task => task.length < 2 || task[1])
       for (let i = 0; i < enabled.length; i++) {
         const fn = enabled[i][0]
-        await this.importProgressHook.invoke(this, { phase: fn.name || 'preImport', step: i + 1, totalSteps: enabled.length })
+        const stage = PROGRESS_STAGES[fn.name || 'preImport']
+        if (stage) await this.importProgressHook.invoke(this, stage)
         await fn.call(this)
       }
       await this.postImportHook.invoke(this)
@@ -633,7 +648,6 @@ class AdaptFrameworkImport {
         }
       }
       imagesImported++
-      await this.importProgressHook.invoke(this, { phase: 'importCourseAssets', current: imagesImported, total: this.assetData.length })
     }))
     log('debug', 'imported course assets successfully')
     this.statusReport.info.push({ code: 'ASSETS_IMPORTED_SUCCESSFULLY', data: { count: imagesImported } })
@@ -819,8 +833,6 @@ class AdaptFrameworkImport {
     }
     const { sorted, hierarchy } = await this.getSortedData()
     const errors = []
-    const total = sorted.reduce((n, ids) => n + ids.length, 0)
-    let current = 0
 
     for (const ids of sorted) {
       for (const _id of ids) {
@@ -833,7 +845,6 @@ class AdaptFrameworkImport {
         } catch (e) {
           errors.push(formatError(e))
         }
-        await this.importProgressHook.invoke(this, { phase: 'importCourseData', current: ++current, total })
       }
     }
     if (errors.length) throw App.instance.errors.FW_IMPORT_CONTENT_FAILED.setData({ errors })

--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -44,7 +44,7 @@ class AdaptFrameworkModule extends AbstractModule {
      */
     this.postImportHook = new Hook()
     /**
-     * Invoked repeatedly during an import to report progress. Observers receive the AdaptFrameworkImport instance and a progress object ({ phase, step, totalSteps, current, total }). Transport-agnostic — consumers relay it as needed (e.g. over a websocket).
+     * Invoked at each import stage transition to report progress. Observers receive the AdaptFrameworkImport instance and a stage object ({ id, labelKey }) — a stable stage id and a langpack key the consumer can resolve. Transport-agnostic — consumers relay it as needed (e.g. over a websocket).
      * @type {Hook}
      */
     this.importProgressHook = new Hook()
@@ -437,7 +437,7 @@ class AdaptFrameworkModule extends AbstractModule {
     const importer = new AdaptFrameworkImport(options)
     importer.preImportHook.tap(() => this.preImportHook.invoke(importer))
     importer.postImportHook.tap(() => this.postImportHook.invoke(importer))
-    importer.importProgressHook.tap(progress => this.importProgressHook.invoke(importer, progress))
+    importer.importProgressHook.tap((_, progress) => this.importProgressHook.invoke(importer, progress))
     if (this.importHook.hasObservers) {
       return this.importHook.invoke(async () => importer.import(), importer)
     }


### PR DESCRIPTION
### Fixes #226

### Fix
- Forward the progress payload in the module `importProgressHook` bridge; it was passing the importer instance, which the websocket relay serialised into an infinite loop (`Maximum call stack size exceeded`).

### Update
- Emit `{ id, labelKey }` stage descriptors from the import loop instead of raw method names + step counts, so consumers render progress without hard-coding the phase list.
- Drop the redundant per-item progress events.

### Testing
- Import a course with a client subscribed to import progress; it completes without the stack-overflow crash and reports stage transitions.