### PR TITLE
Update: consume @adapt-security/zipper from npm

### DIFF
--- a/lib/AdaptFrameworkBuild.js
+++ b/lib/AdaptFrameworkBuild.js
@@ -8,7 +8,7 @@ import BuildCache from './BuildCache.js'
 import fs from 'node:fs/promises'
 import path from 'upath'
 import semver from 'semver'
-import zipper from 'zipper'
+import zipper from '@adapt-security/zipper'
 
 /**
  * Encapsulates all behaviour needed to build a single Adapt course instance

--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises'
 import { glob } from 'glob'
 import path from 'upath'
 import semver from 'semver'
-import { unzip } from 'zipper'
+import { unzip } from '@adapt-security/zipper'
 import { log, logDir, getImportSummary, getImportContentCounts, readFrameworkPluginVersions, collectMigrationScripts, runContentMigration, reconcileAssetTags, resolvePluginAction, resolvePluginUpdatePolicy } from './utils.js'
 
 import ComponentTransform from './migrations/component.js'

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.21",
     "semver": "^7.6.0",
     "upath": "^2.0.1",
-    "zipper": "github:adapt-security/zipper#v1.1.0"
+    "@adapt-security/zipper": "^1.2.0"
   },
   "peerDependencies": {
     "adapt-authoring-assets": "^1.4.3",


### PR DESCRIPTION
### Fixes #228

### Update
- Switch the `zipper` dependency from `github:adapt-security/zipper` to `@adapt-security/zipper@^1.2.0` (now published to npm — see adapt-security/zipper#50).
- Update the import specifier accordingly. Same default/named import binding; no behaviour change.

### Testing
- `npx standard` clean.
- `npm test` — full suite passes.
- Verified `@adapt-security/zipper@1.2.0` resolves and its `zip`/`unzip` exports load in a linked workspace install.