### PR TITLE
Update: Resolve content access via the generic _access grants (fixes #194)

### DIFF
--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -4,7 +4,7 @@ import AdaptFrameworkImport from './AdaptFrameworkImport.js'
 import fs from 'node:fs/promises'
 import { getHandler, postHandler, importHandler, postUpdateHandler, getUpdateHandler } from './handlers.js'
 import { loadRouteConfig, registerRoutes } from 'adapt-authoring-server'
-import { applyContentAccessFilter, runCliCommand, readFrameworkPluginVersions, migrateExistingCourses, computePluginHash, prebuildCache } from './utils.js'
+import { applyContentAccessFilter, courseAccessGranted, runCliCommand, readFrameworkPluginVersions, migrateExistingCourses, computePluginHash, prebuildCache } from './utils.js'
 import BuildCache from './BuildCache.js'
 import path from 'node:path'
 import semver from 'semver'
@@ -345,23 +345,19 @@ class AdaptFrameworkModule extends AbstractModule {
    */
   async checkContentAccess (req, data) {
     const content = await this.app.waitForModule('content')
-    let course
-    if (data._type === 'course') {
-      course = data
-    } else {
-      course = await content.findOne({ _id: data._courseId || (await content.findOne(data, { strict: false }))?._courseId })
-    }
+    const course = data._type === 'course'
+      ? data
+      : await content.findOne(
+        { _id: data._courseId || (await content.findOne(data, { strict: false }))?._courseId },
+        { validate: false },
+        { projection: { _access: 1, createdBy: 1 } }
+      )
     if (!course) {
       return
     }
-    const shareWithUsers = course._shareWithUsers?.map(id => id.toString()) ?? []
     const userId = req.auth.user._id.toString()
     const userGroups = (req.auth.user.userGroups ?? []).map(id => id.toString())
-    const courseGroups = (course.userGroups ?? []).map(id => id.toString())
-    return course.createdBy.toString() === userId ||
-      course._isShared ||
-      shareWithUsers.includes(userId) ||
-      courseGroups.some(g => userGroups.includes(g))
+    return courseAccessGranted(course, userId, userGroups)
   }
 
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 export { applyContentAccessFilter } from './utils/applyContentAccessFilter.js'
+export { courseAccessGranted } from './utils/courseAccessGranted.js'
 export { inferBuildAction } from './utils/inferBuildAction.js'
 export { getPluginUpdateStatus } from './utils/getPluginUpdateStatus.js'
 export { resolvePluginAction } from './utils/resolvePluginAction.js'

--- a/lib/utils/applyContentAccessFilter.js
+++ b/lib/utils/applyContentAccessFilter.js
@@ -1,9 +1,9 @@
 /**
- * Mutates a mongo content query so it only matches courses the given user can access:
- * owned by them, marked public via `_isShared`, in `_shareWithUsers`, or shared with one
- * of the user's groups (`userGroups`). All are additive grants — sharing a course via any
- * dimension widens access. Combines safely with an existing `$or` (e.g. from search) by
- * lifting both into `$and`.
+ * Mutates a mongo content query so it only matches courses the given user can access via
+ * the generic `_access` grants: owned by them (`createdBy`), public (`_access.public`), in
+ * `_access.users`, or shared with one of the user's groups (`_access.groups`). All are
+ * additive grants — sharing a course via any dimension widens access. Combines safely with
+ * an existing `$or` (e.g. from search) by lifting both into `$and`.
  * @param {object} query The mongo query object to mutate
  * @param {string} userId The user's `_id` (already coerced to string)
  * @param {Array} [userGroups] The user's group ids; adds a group-sharing grant when present
@@ -13,12 +13,12 @@ export function applyContentAccessFilter (query, userId, userGroups = []) {
   if (!userId) return
   const clauses = [
     { createdBy: userId },
-    { _isShared: true },
-    { _shareWithUsers: userId }
+    { '_access.public': true },
+    { '_access.users': userId }
   ]
   // a course shared with any group the user belongs to (optional dimension —
   // only present when the usergroups module is in use)
-  if (userGroups?.length) clauses.push({ userGroups: { $in: userGroups } })
+  if (userGroups?.length) clauses.push({ '_access.groups': { $in: userGroups } })
   if (query.$or) {
     query.$and = [
       ...(query.$and ?? []),

--- a/lib/utils/courseAccessGranted.js
+++ b/lib/utils/courseAccessGranted.js
@@ -1,0 +1,20 @@
+/**
+ * Determines whether a user may access a course based on its generic `_access` grants
+ * (public / per-user / per-group) plus `createdBy` ownership. Additive: any matching
+ * dimension grants access. This is the per-item equivalent of the clauses built by
+ * `applyContentAccessFilter`, used by the content access resolver so that a course and
+ * all its descendants are judged by the course's access.
+ * @param {Object} course The course document (needs `_access` and `createdBy`)
+ * @param {String} userId The requesting user's id (stringified)
+ * @param {Array} [userGroups] The requesting user's group memberships
+ * @return {Boolean}
+ * @memberof adaptframework
+ */
+export function courseAccessGranted (course, userId, userGroups = []) {
+  if (!course) return false
+  const groups = userGroups.map(g => g.toString())
+  return course._access?.public === true ||
+    course.createdBy?.toString() === userId ||
+    (course._access?.users ?? []).some(u => u.toString() === userId) ||
+    (course._access?.groups ?? []).some(g => groups.includes(g.toString()))
+}

--- a/migrations/3.6.0.js
+++ b/migrations/3.6.0.js
@@ -1,0 +1,26 @@
+/**
+ * Backfills the generic `_access` grants on courses from the legacy sharing fields,
+ * preserving existing semantics. Legacy `_isShared` / `_shareWithUsers` are left in place
+ * until the contract step (#224). The `userGroups` → `_access.groups` mapping is owned by
+ * the usergroups module.
+ *
+ * `_access.public` is written EXPLICITLY (not left to the schema default of `true`) so that
+ * previously-private courses (`_isShared` falsy) stay private after the migration.
+ * Idempotent: only touches course documents that don't yet carry `_access.public`.
+ */
+export default function (migration) {
+  migration.describe('Backfill course _access.public/_access.users from legacy _isShared/_shareWithUsers')
+  migration.runCommand(backfillCourseAccess)
+}
+
+async function backfillCourseAccess (db) {
+  return db.collection('content').updateMany(
+    { _type: 'course', '_access.public': { $exists: false } },
+    [{
+      $set: {
+        '_access.public': { $eq: ['$_isShared', true] },
+        '_access.users': { $ifNull: ['$_shareWithUsers', []] }
+      }
+    }]
+  )
+}

--- a/tests/utils-applyContentAccessFilter.spec.js
+++ b/tests/utils-applyContentAccessFilter.spec.js
@@ -14,8 +14,8 @@ describe('applyContentAccessFilter()', () => {
     applyContentAccessFilter(query, 'user1')
     assert.deepEqual(query.$or, [
       { createdBy: 'user1' },
-      { _isShared: true },
-      { _shareWithUsers: 'user1' }
+      { '_access.public': true },
+      { '_access.users': 'user1' }
     ])
   })
 
@@ -24,9 +24,9 @@ describe('applyContentAccessFilter()', () => {
     applyContentAccessFilter(query, 'user1', ['g1', 'g2'])
     assert.deepEqual(query.$or, [
       { createdBy: 'user1' },
-      { _isShared: true },
-      { _shareWithUsers: 'user1' },
-      { userGroups: { $in: ['g1', 'g2'] } }
+      { '_access.public': true },
+      { '_access.users': 'user1' },
+      { '_access.groups': { $in: ['g1', 'g2'] } }
     ])
   })
 
@@ -34,7 +34,7 @@ describe('applyContentAccessFilter()', () => {
     const query = { _type: 'course' }
     applyContentAccessFilter(query, 'user1', [])
     assert.equal(query.$or.length, 3)
-    assert.ok(!query.$or.some(c => c.userGroups))
+    assert.ok(!query.$or.some(c => c['_access.groups']))
   })
 
   it('should preserve an existing $or by lifting both into $and', () => {
@@ -46,8 +46,8 @@ describe('applyContentAccessFilter()', () => {
       {
         $or: [
           { createdBy: 'user1' },
-          { _isShared: true },
-          { _shareWithUsers: 'user1' }
+          { '_access.public': true },
+          { '_access.users': 'user1' }
         ]
       }
     ])

--- a/tests/utils-courseAccessGranted.spec.js
+++ b/tests/utils-courseAccessGranted.spec.js
@@ -1,0 +1,23 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { courseAccessGranted } from '../lib/utils/courseAccessGranted.js'
+
+describe('courseAccessGranted()', () => {
+  const cases = [
+    { name: 'no course', course: null, userId: 'u1', userGroups: [], expected: false },
+    { name: 'public course', course: { _access: { public: true } }, userId: 'u1', userGroups: [], expected: true },
+    { name: 'private course, non-owner, no shares', course: { _access: { public: false }, createdBy: 'u2' }, userId: 'u1', userGroups: [], expected: false },
+    { name: 'owner', course: { _access: { public: false }, createdBy: 'u1' }, userId: 'u1', userGroups: [], expected: true },
+    { name: 'shared with user', course: { _access: { public: false, users: ['u1'] } }, userId: 'u1', userGroups: [], expected: true },
+    { name: 'not shared with user', course: { _access: { public: false, users: ['u2'] } }, userId: 'u1', userGroups: [], expected: false },
+    { name: 'shared with a group the user is in', course: { _access: { public: false, groups: ['g2'] } }, userId: 'u1', userGroups: ['g1', 'g2'], expected: true },
+    { name: 'shared with a group the user is not in', course: { _access: { public: false, groups: ['g3'] } }, userId: 'u1', userGroups: ['g1', 'g2'], expected: false },
+    { name: 'no _access at all (private by absence)', course: { createdBy: 'u2' }, userId: 'u1', userGroups: [], expected: false },
+    { name: 'ObjectId-like owner via toString', course: { createdBy: { toString: () => 'u1' } }, userId: 'u1', userGroups: [], expected: true }
+  ]
+  for (const { name, course, userId, userGroups, expected } of cases) {
+    it(`should return ${expected}: ${name}`, () => {
+      assert.equal(courseAccessGranted(course, userId, userGroups), expected)
+    })
+  }
+})


### PR DESCRIPTION
### Fixes #194

### Update
- Retarget the content access checks from the legacy sharing fields to the generic `_access` grants. Both access paths are kept (they're needed for content's hierarchy — see below) but now read `_access.public` / `_access.users` / `_access.groups` + `createdBy` instead of `_isShared` / `_shareWithUsers` / `userGroups`:
  - `checkContentAccess` (per-item / `accessCheckHook`) — resolves any content item to its parent course and grants via the course's `_access`. Grant logic extracted to a pure `courseAccessGranted` util.
  - `applyContentAccessFilter` (query-level / `accessQueryHook`, course lists only) — merges `_access` clauses.

### New
- `migrations/3.6.0.js`: backfill course `_access` from legacy fields — `_isShared → _access.public`, `_shareWithUsers → _access.users`. `_access.public` is written **explicitly** (the schema default is `true`, so un-migrated private courses would otherwise flip public). Legacy fields retained until the contract step (#224). The `userGroups → _access.groups` backfill is owned by usergroups.

### Testing
- New `utils-courseAccessGranted.spec.js`; `utils-applyContentAccessFilter.spec.js` updated to the `_access` clauses. Full suite passes (236 tests, run with `--experimental-test-module-mocks`); `npx standard` clean.

### Notes
- **Deviation from the original issue** (deliberate, discussed): the issue proposed *deleting* both paths and relying purely on per-item generic grants. That would break **child-content inheritance** — a page/block is judged on its *own* `_access`, which defaults to `public: true`, leaking children of a private course. Content access is inherently *course-level*, so a single course-resolving authority is retained; it just reads `_access` now. A companion change to content (#117) scopes the `_access` schema fields to the `course` schema and drops content's per-item enforcement taps so nested items can't self-grant.
- Part of the `_access` rollout (api #98); lands in the coordinated umbrella release with usergroups #14, assets #66 and content #117.
