### PR TITLE
Update: Report asset counts in the import summary (fixes #233)

### DIFF
--- a/lib/AdaptFrameworkImport.js
+++ b/lib/AdaptFrameworkImport.js
@@ -196,6 +196,11 @@ class AdaptFrameworkImport {
      */
     this.newAssetIds = []
     /**
+     * Asset IDs matched to existing records by content hash rather than created. On a dry run these are the assets that would be reused.
+     * @type {Array<String>}
+     */
+    this.reusedAssetIds = []
+    /**
      * Contains non-fatal infomation messages regarding import status which can be return as response data. Fatal errors are thrown in the usual way.
      * @type {Object}
      */
@@ -614,10 +619,15 @@ class AdaptFrameworkImport {
       const filepath = data.filepath ?? (await glob(`*/${data.filename}`, { cwd: this.langPath, absolute: true, posix: true }))[0]
       // remove unused filepath to avoid possible issues
       delete data.filepath
+      const stats = await fs.stat(filepath)
       if (this.settings.isDryRun) {
+        try {
+          await this.assets.checkDuplicate(filepath, stats.size)
+        } catch (e) {
+          if (e.code === 'DUPLICATE_ASSET') this.reusedAssetIds.push(e.data.assetId)
+        }
         return
       }
-      const stats = await fs.stat(filepath)
       try {
         const asset = await this.assets.insert({
           ...data,
@@ -638,6 +648,7 @@ class AdaptFrameworkImport {
         if (e.code === 'DUPLICATE_ASSET') {
           const resolved = path.relative(`${this.coursePath}/..`, filepath)
           this.assetMap[resolved] = e.data.assetId
+          this.reusedAssetIds.push(e.data.assetId)
           // existing asset persisted by content hash: prune its stale tag refs, merge this import's (#212)
           const [existing] = await this.assets.find({ _id: e.data.assetId })
           const tags = reconcileAssetTags(existing?.tags, data.tags, this.validTagIds)

--- a/lib/utils/getImportSummary.js
+++ b/lib/utils/getImportSummary.js
@@ -10,6 +10,10 @@ import { getImportContentCounts } from './getImportContentCounts.js'
  * @property {Object<String>} statusReport.info Information messages
  * @property {Array<String>} statusReport.warn Warning messages
  * @property {Object} content Object mapping content types to the number of items of that type found in the imported course
+ * @property {Object} assets Counts of assets referenced by the imported course
+ * @property {Number} assets.total Total assets referenced by the course
+ * @property {Number} assets.imported Assets created by this import (on a dry run, those that would be created)
+ * @property {Number} assets.reused Assets matched to an existing record by content hash rather than created (on a dry run, those that would be reused)
  * @property {Object} versions A map of plugins used in the imported course and their versions
  *
  * @param {AdaptFrameworkImport} importer The import instance
@@ -30,7 +34,10 @@ export async function getImportSummary (importer) {
     usedContentPlugins: usedPlugins,
     newContentPlugins: newPlugins,
     statusReport,
-    settings: { pluginUpdatePolicy }
+    assetData,
+    newAssetIds,
+    reusedAssetIds,
+    settings: { pluginUpdatePolicy, isDryRun }
   } = importer
   const versions = [
     { name: fwName, versions: [framework.version, fwVersion] },
@@ -50,6 +57,11 @@ export async function getImportSummary (importer) {
     courseId,
     statusReport,
     content: getImportContentCounts(contentJson),
+    assets: {
+      total: assetData.length,
+      imported: isDryRun ? Math.max(0, assetData.length - reusedAssetIds.length) : newAssetIds.length,
+      reused: reusedAssetIds.length
+    },
     versions
   }
 }


### PR DESCRIPTION
### Fixes #233

### Update
- getImportSummary now returns assets: { total, imported, reused } alongside the content and version reports.
- The dry-run import classifies each asset via the assets modules content-hash checkDuplicate, so the pre-import check can predict how many assets are new versus reused. On a real import these are the actual created and deduplicated counts.

### Testing
- Dry-run import of a course archive returns accurate total/imported/reused values (verified against a course with 16 assets: 2 new, 14 reused).