### PR TITLE
New: add buildProgressHook to report build phase progress (fixes #235)

### DIFF
--- a/lib/AdaptFrameworkBuild.js
+++ b/lib/AdaptFrameworkBuild.js
@@ -46,12 +46,18 @@ class AdaptFrameworkBuild {
    * @constructor
    * @param {AdaptFrameworkBuildOptions} options
    */
-  constructor ({ action, courseId, userId, expiresAt, compress, outputDir }) {
+  constructor ({ action, courseId, userId, expiresAt, compress, outputDir, buildToken }) {
     /**
      * The MongoDB collection name
      * @type {String}
      */
     this.collectionName = 'adaptbuilds'
+    /**
+     * Progress correlation id; when set, build phases are reported to the
+     * adaptframework `buildProgressHook` for relay to a subscribed client.
+     * @type {String}
+     */
+    this.buildToken = buildToken
     /**
      * The build action being performed
      * @type {String}
@@ -198,6 +204,10 @@ class AdaptFrameworkBuild {
     logDir('buildDir', this.buildDir)
     logDir('cacheDir', this.cacheDir)
 
+    // best-effort per-phase progress to a subscribed client (no-op without a buildToken)
+    const reportPhase = (id, labelKey) => this.buildToken ? framework.buildProgressHook.invoke(this, { id, labelKey }) : null
+
+    await reportPhase('prepare', 'app.previewbuildstepprepare')
     await this.loadCourseData()
 
     // must hash before preBuildHook/applySchemaDefaults mutate course.data
@@ -225,11 +235,13 @@ class AdaptFrameworkBuild {
         })
         this.location = path.join(this.dir, 'build')
         await this.postBuildHook.invoke(this)
+        await reportPhase('package', 'app.previewbuildsteppackage')
         this.buildData = await this.recordBuildAttempt()
         return this
       }
     }
 
+    await reportPhase('assemble', 'app.previewbuildstepassemble')
     const tasks = [this.copyAssets()]
     if (!contentOnly) {
       const pluginsToInclude = getBundledPlugins(this.isPreview, this.enabledPlugins, this.disabledPlugins)
@@ -243,6 +255,7 @@ class AdaptFrameworkBuild {
 
     await this.preBuildHook.invoke(this)
 
+    await reportPhase('content', 'app.previewbuildstepcontent')
     await this.applySchemaDefaults()
     await this.writeContentJson()
 
@@ -251,6 +264,7 @@ class AdaptFrameworkBuild {
     if (!contentOnly && !this.isExport) {
       try {
         logMemory()
+        await reportPhase('compile', 'app.previewbuildstepcompile')
         await AdaptCli.buildCourse({
           cwd: this.dir,
           sourceMaps: !this.isPublish,
@@ -277,6 +291,7 @@ class AdaptFrameworkBuild {
         log('warn', 'CACHE', `failed to populate prebuilt cache: ${e.message}`)
       }
     }
+    await reportPhase('package', 'app.previewbuildsteppackage')
     if (this.compress) {
       this.location = await this.prepareZip()
     } else {

--- a/lib/AdaptFrameworkModule.js
+++ b/lib/AdaptFrameworkModule.js
@@ -49,6 +49,11 @@ class AdaptFrameworkModule extends AbstractModule {
      */
     this.importProgressHook = new Hook()
     /**
+     * Invoked at each build phase transition to report progress. Observers receive the AdaptFrameworkBuild instance (which carries `buildToken`) and a stage object ({ id, labelKey }). Transport-agnostic — consumers relay it as needed (e.g. over a websocket), mirroring importProgressHook.
+     * @type {Hook}
+     */
+    this.buildProgressHook = new Hook()
+    /**
      * Invoked prior to a course being built. The AdaptFrameworkBuild instance is passed to any observers.
      * @type {Hook}
      */

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -52,10 +52,12 @@ export async function postHandler (req, res, next) {
   const action = inferBuildAction(req)
   const courseId = req.params.id
   const userId = req.auth.user._id.toString()
+  // optional progress correlation id (the client subscribes with the same id)
+  const buildToken = req.query.buildToken
 
   log('info', `running ${action} for course '${courseId}' initiated by ${userId}`)
   try {
-    const { isPreview, buildData } = await framework.buildCourse({ action, courseId, userId })
+    const { isPreview, buildData } = await framework.buildCourse({ action, courseId, userId, buildToken })
     const duration = Math.round((Date.now() - startTime) / 10) / 100
     log('info', `finished ${action} for course '${courseId}' in ${duration} seconds`)
     const urlRoot = isPreview ? framework.rootRouter.url : framework.apiRouter.url


### PR DESCRIPTION
### Fixes #235

### New
* Add a `buildProgressHook` (mirroring `importProgressHook`), invoked at each phase of `AdaptFrameworkBuild.build()` with a `{ id, labelKey }` stage object — `prepare → assemble → content → compile → package` (and the cached-preview fast path). Transport-agnostic: the framework just invokes the hook; consumers relay it however they like.
* Thread an optional `buildToken` from the build request (`handlers.js` → `buildCourse(options)` → `AdaptFrameworkBuild`) so observers can attribute progress events to a specific build. No-op when unset, so existing callers are unaffected.

### Testing
* `npx standard` clean.
* Verified a preview build invokes the hook with the full phase sequence in order, and that omitting `buildToken` is a clean no-op (no behaviour change for existing callers).
